### PR TITLE
ui: touching a selected item validates user choice

### DIFF
--- a/core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java
@@ -120,6 +120,11 @@ public class SelectChampionshipScreen extends PwStageScreen {
             public void currentChanged(Championship championship, int index) {
                 updateChampionshipDetails(championship);
             }
+
+            @Override
+            public void confirmSelection() {
+                next();
+            }
         });
     }
 

--- a/core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java
@@ -133,6 +133,11 @@ public class SelectTrackScreen extends PwStageScreen {
             public void currentChanged(Track track, int index) {
                 updateTrackRecords(track);
             }
+
+            @Override
+            public void confirmSelection() {
+                next();
+            }
         });
     }
 

--- a/core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java
@@ -110,6 +110,11 @@ public class SelectVehicleScreen extends PwStageScreen {
             public void currentChanged(VehicleDef vehicle, int index) {
                 updateVehicleDetails(vehicle);
             }
+
+            @Override
+            public void confirmSelection() {
+                next();
+            }
         });
     }
 

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -65,6 +65,7 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
     public interface SelectionListener<T> {
         void selectedChanged(T item, int index);
         void currentChanged(T item, int index);
+        void confirmSelection();
     }
 
     public static class GridMenuItemStyle {
@@ -132,6 +133,13 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
             mSelectedIndex = -1;
             if (mSelectionListener != null) {
                 mSelectionListener.selectedChanged(null, -1);
+            }
+            return;
+        }
+        // Selection does not change, consider this as a confirmation
+        if (mSelectedIndex == index) {
+            if (mSelectionListener != null) {
+                mSelectionListener.confirmSelection();
             }
             return;
         }


### PR DESCRIPTION
Make sure that if an already selected item (track, car or championship)
is touched / clicked, selection is confirmed and we proceed to next screen.

This make the ui more pleasant, and faster.

This contribution is sponsored by my company, Genymobile, for #hacktoberfest.