### PR TITLE
Fix crash when pressung up/down in keyboard config screen

### DIFF
--- a/core/src/com/agateau/ui/menu/MenuItemGroup.java
+++ b/core/src/com/agateau/ui/menu/MenuItemGroup.java
@@ -119,7 +119,7 @@ public class MenuItemGroup implements MenuItem {
 
     @Override
     public boolean goDown() {
-        if (getCurrentItem().goDown()) {
+        if (getCurrentItem() != null && getCurrentItem().goDown()) {
             return true;
         }
         return adjustIndex(mCurrentIndex, 1);
@@ -127,7 +127,7 @@ public class MenuItemGroup implements MenuItem {
 
     @Override
     public boolean goUp() {
-        if (getCurrentItem().goUp()) {
+        if (getCurrentItem() != null && getCurrentItem().goUp()) {
             return true;
         }
         return adjustIndex(mCurrentIndex, -1);


### PR DESCRIPTION
getCurrentItem() is returning null in the keyboard config
screen because there are no items to be focused. The
goUp() and goDown() methods did not account for that.