### PR TITLE
Fix tools/po-update

### DIFF
--- a/tools/po-update
+++ b/tools/po-update
@@ -9,7 +9,7 @@ TOOLS_DIR=$PWD/tools
 PO_DIR=$PWD/android/assets/po
 MESSAGES_POT=$PO_DIR/messages.pot
 
-TEMP_DIR="$(mktemp -d -- "${TMPDIR}/po-update-XXXXXX")"
+TEMP_DIR="$(mktemp -d --tmpdir "po-update-XXXXXX")"
 
 delete_temp_dir() {
     rm -rf $TEMP_DIR


### PR DESCRIPTION
In this pull request I applied small fix to `tools/po-update` file to make it work on more platforms. For example I'm using Termux so temporary directory is located at `/data/data/com.termux/files/usr/tmp` instead of `/tmp` which causes some issues unless you use `$TMPDIR` variable.