### PR TITLE
Fix PR branches being build twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,13 @@
 name: main
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      # Only build on push for master or dev, otherwise branches pushed for PR
+      # are built twice
+      - master
+      - dev
 
 jobs:
   build:


### PR DESCRIPTION
Do not build on push unless when pushing to master or dev.
