### PR TITLE
Fix ambiguous "You broke a record" message

### DIFF
--- a/android/assets/po/bn.po
+++ b/android/assets/po/bn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -409,52 +409,61 @@ msgstr "ক্রম"
 msgid "Race Results"
 msgstr "প্রতিযোগিতার ফল"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+#, fuzzy
+msgid "Congratulations, great race!"
+msgstr ""
 "অভিনন্দন!\n"
 "তুমি একটি সীমা(রেকর্ড) ভেঙেছো!"
-msgstr[1] ""
-"অভিনন্দন!\n"
-"তুমি %#টি সীমা(রেকর্ড) ভেঙেছো!"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr "#"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr "সর্বোত্তম দৌড়"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr "দৌড়বিদ"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr "মোট সময়"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr "পয়েন্ট"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr "দৌড়ের সময়"
 

--- a/android/assets/po/es.po
+++ b/android/assets/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: 2021-10-30 17:54+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -410,52 +410,61 @@ msgstr "Clasificación del campeonato"
 msgid "Race Results"
 msgstr "Resultado de la carrera"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+#, fuzzy
+msgid "Congratulations, great race!"
+msgstr ""
 "Felicitaciones !\n"
 "Batió uno récord !"
-msgstr[1] ""
-"Felicitaciones !\n"
-"Batió %# récord !"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr "N.°"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr "Mejor vuelta"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr "Piloto"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr "Tiempo total"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr "Puntos"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr "Tiempo de carrera"
 

--- a/android/assets/po/fr.po
+++ b/android/assets/po/fr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: 2021-10-28 20:25+0200\n"
 "Last-Translator: Aurélien Gâteau <mail@agateau.com>\n"
 "Language-Team: French <>\n"
@@ -408,52 +408,61 @@ msgstr "Classement du championnat"
 msgid "Race Results"
 msgstr "Résultats de la course"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+#, fuzzy
+msgid "Congratulations, great race!"
+msgstr ""
 "Félicitations !\n"
 "Record battu !"
-msgstr[1] ""
-"Félicitations !\n"
-"%# records battus !"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr "N°"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr "Meilleur tour"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr "Pilote"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr "Temps total"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr "Points"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr "Temps de course"
 

--- a/android/assets/po/messages.pot
+++ b/android/assets/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -408,48 +408,58 @@ msgstr ""
 msgid "Race Results"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
-msgstr[1] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+msgid "Congratulations, great race!"
+msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr ""
 

--- a/android/assets/po/pl.po
+++ b/android/assets/po/pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: 2021-11-08 21:33+0000\n"
 "Last-Translator: PandaCoderPL <translator@pandacoderpl.anonaddy.me>\n"
 "Language-Team: Polish <>\n"
@@ -11,7 +11,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 #: android/assets/screens/credits.gdxui:6
 msgid "Pixel Wheels"
@@ -408,55 +409,61 @@ msgstr "Rankingi Mistrzostw"
 msgid "Race Results"
 msgstr "Wyniki Wyścigów"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+#, fuzzy
+msgid "Congratulations, great race!"
+msgstr ""
 "Gratulacje!\n"
 "Pobiłeś rekord!"
-msgstr[1] ""
-"Gratulacje!\n"
-"Pobiłeś %# rekordy!"
-msgstr[2] ""
-"Gratulacje!\n"
-"Pobiłeś %# rekordów!"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr "#"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr "Najlepsze okrążenie"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr "Zawodnik"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr "Łączny czas"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr "Punkty"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr "Czas wyścigu"
 

--- a/android/assets/po/zh_CN.po
+++ b/android/assets/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 07:58+0100\n"
+"POT-Creation-Date: 2021-12-13 18:56+0100\n"
 "PO-Revision-Date: 2021-11-06 21:20+0800\n"
 "Last-Translator: Lu Xu <oliver_lew@outlook.com>\n"
 "Language-Team: \n"
@@ -405,49 +405,61 @@ msgstr "锦标赛排名"
 msgid "Race Results"
 msgstr "竞赛结果"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:304
-msgid ""
-"Congratulations!\n"
-"You broke a record!"
-msgid_plural ""
-"Congratulations!\n"
-"You broke %# records!"
-msgstr[0] ""
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:320
+#, fuzzy
+msgid "Congratulations, great race!"
+msgstr ""
 "恭喜！\n"
 "你打破了 %# 项记录！"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:321
+msgid "You've got some serious driving skills!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:322
+msgid "You're a champ!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:323
+msgid "Congrats for this performance!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:324
+msgid "Impressive!"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "#"
 msgstr "#"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 msgid "Best lap"
 msgstr "最佳单圈"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Racer"
 msgstr "赛车手"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:400
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:408
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Total time"
 msgstr "总用时"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:404
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:412
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
 msgid "Points"
 msgstr "分数"
 
-#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:407
+#: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 msgid "Race time"
 msgstr "比赛时间"
 

--- a/android/assets/screens/finishedoverlay.gdxui
+++ b/android/assets/screens/finishedoverlay.gdxui
@@ -40,7 +40,7 @@
             </Items>
         </Menu>
 
-        <Ifdef var="recordBroken">
+        <Ifdef var="showCongratsCar">
             <Image id="car" name="congrats-car" bottomLeft="root.bottomCenter 12g 0" visible="false">
                 <Action>
                     delay 2.2
@@ -50,7 +50,7 @@
                     moveBy -12g 0 0.5 pow4Out
                 </Action>
             </Image>
-            <Label id="recordBrokenLabel" bottomCenter="car.topCenter -3g 1g" style="speechBubble"
+            <Label id="congratsCarLabel" bottomCenter="car.topCenter -3g 1g" style="speechBubble"
                 align="center" visible="false" width="12g" wrap="true">
                 <Action>
                     delay 2.6

--- a/android/assets/screens/finishedoverlay.gdxui
+++ b/android/assets/screens/finishedoverlay.gdxui
@@ -11,7 +11,7 @@
             alpha 0.0
             moveBy -5g 15g
             rotateBy 360
-            delay 1.6
+            delay 0.8
             parallel
                 alpha 1 0.4
                 moveBy 0 -15g 1 bounceOut
@@ -43,16 +43,17 @@
         <Ifdef var="recordBroken">
             <Image id="car" name="congrats-car" bottomLeft="root.bottomCenter 12g 0" visible="false">
                 <Action>
-                    delay 1
+                    delay 2.2
                     // delay before moveBy so that moveBy happens after anchor layout
                     moveBy 12g 0
                     show
                     moveBy -12g 0 0.5 pow4Out
                 </Action>
             </Image>
-            <Label id="recordBrokenLabel" bottomCenter="car.topCenter -3g 1g" style="speechBubble" align="center" visible="false">
+            <Label id="recordBrokenLabel" bottomCenter="car.topCenter -3g 1g" style="speechBubble"
+                align="center" visible="false" width="12g" wrap="true">
                 <Action>
-                    delay 1.4
+                    delay 2.6
                     alpha 0
                     show
                     alpha 1 0.2

--- a/core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java
@@ -19,7 +19,6 @@
 package com.agateau.pixelwheels.racescreen;
 
 import static com.agateau.translations.Translator.tr;
-import static com.agateau.translations.Translator.trn;
 
 import com.agateau.pixelwheels.PwGame;
 import com.agateau.pixelwheels.PwRefreshHelper;
@@ -41,6 +40,7 @@ import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -297,14 +297,9 @@ public class FinishedOverlay extends Overlay {
         fillMenu(builder);
         fillTable(table, tableType, oldRankMap);
         if (!mRecordAnimInfos.isEmpty()) {
-            int count = mRecordAnimInfos.size;
             Label label = builder.getActor("recordBrokenLabel");
-            label.setText(
-                    trn(
-                            "Congratulations!\nYou broke a record!",
-                            "Congratulations!\nYou broke %# records!",
-                            count));
-            label.pack();
+            label.setText(pickRecordLabelText());
+            label.setHeight(label.getPrefHeight());
             // Create animations after the Overlay is at its final position, to ensure the table
             // cell coordinates are final
             Timer.schedule(
@@ -317,6 +312,19 @@ public class FinishedOverlay extends Overlay {
                     Overlay.IN_DURATION);
         }
         return content;
+    }
+
+    private String pickRecordLabelText() {
+        String[] messages =
+                new String[] {
+                    tr("Congratulations, great race!"),
+                    tr("You've got some serious driving skills!"),
+                    tr("You're a champ!"),
+                    tr("Congrats for this performance!"),
+                    tr("Impressive!"),
+                };
+        int idx = MathUtils.random(messages.length - 1);
+        return messages[idx];
     }
 
     private void loadRankChangeAnimations(UiBuilder builder) {

--- a/core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java
@@ -267,8 +267,10 @@ public class FinishedOverlay extends Overlay {
         if (!isChampionship()) {
             builder.defineVariable("quickRace");
         }
-        if (tableType != TableType.CHAMPIONSHIP_TOTAL && didPlayerBreakRecord()) {
-            builder.defineVariable("recordBroken");
+        boolean showCongratsCar =
+                tableType != TableType.CHAMPIONSHIP_TOTAL && shouldShowCongratsCar();
+        if (showCongratsCar) {
+            builder.defineVariable("showCongratsCar");
         }
         HashMap<Racer, Integer> oldRankMap = null;
         if (tableType == TableType.CHAMPIONSHIP_TOTAL) {
@@ -296,10 +298,14 @@ public class FinishedOverlay extends Overlay {
 
         fillMenu(builder);
         fillTable(table, tableType, oldRankMap);
-        if (!mRecordAnimInfos.isEmpty()) {
-            Label label = builder.getActor("recordBrokenLabel");
-            label.setText(pickRecordLabelText());
+
+        if (showCongratsCar) {
+            Label label = builder.getActor("congratsCarLabel");
+            label.setText(pickCongratsCarLabelText());
             label.setHeight(label.getPrefHeight());
+        }
+
+        if (!mRecordAnimInfos.isEmpty()) {
             // Create animations after the Overlay is at its final position, to ensure the table
             // cell coordinates are final
             Timer.schedule(
@@ -314,7 +320,7 @@ public class FinishedOverlay extends Overlay {
         return content;
     }
 
-    private String pickRecordLabelText() {
+    private String pickCongratsCarLabelText() {
         String[] messages =
                 new String[] {
                     tr("Congratulations, great race!"),
@@ -539,8 +545,10 @@ public class FinishedOverlay extends Overlay {
         return mRaceScreen.getGameType() == GameInfo.GameType.CHAMPIONSHIP;
     }
 
-    private boolean didPlayerBreakRecord() {
-        for (Racer racer : mRacers) {
+    private boolean shouldShowCongratsCar() {
+        // Show congrats car if player entered the record table and is ranked 3rd or better
+        for (int idx = 0; idx < 3; ++idx) {
+            Racer racer = mRacers.get(idx);
             if (racer.getRecordRanks().brokeRecord()) {
                 return true;
             }


### PR DESCRIPTION
This PR works around the wording issue reported in #139, by using more a generic message. To make it more interesting, the message is randomly picked from a selection of congratulation messages.

![screenshot-2021-12-13-190216 178](https://user-images.githubusercontent.com/3575/145864643-2fc24c08-058d-4bd7-8525-cd4aec2fae88.png)
![screenshot-2021-12-13-190226 486](https://user-images.githubusercontent.com/3575/145864666-92145c6f-002b-4fae-9714-cc28f27ab204.png)
![screenshot-2021-12-13-190210 377](https://user-images.githubusercontent.com/3575/145864693-7fd86f0d-f6a4-4635-b38b-06080bac12f9.png)

