### PR TITLE
trackeditor: implement redo and selected points labels

### DIFF
--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/DeleteSectionAction.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/DeleteSectionAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.pixelwheels.tools.trackeditor;
+
+import com.agateau.pixelwheels.map.LapPositionTableIO;
+
+class DeleteSectionAction extends EditorAction {
+    private int mRemovedLineIdx;
+    private LapPositionTableIO.Line mRemovedLine;
+
+    public DeleteSectionAction(Editor editor) {
+        super(editor);
+    }
+
+    @Override
+    public void undo() {
+        editor().lines().insert(mRemovedLineIdx, mRemovedLine);
+        editor().setCurrentLineIdx(mRemovedLineIdx);
+        editor().markNeedSave();
+    }
+
+    @Override
+    public void redo() {
+        mRemovedLineIdx = editor().currentLineIdx();
+        mRemovedLine = editor().lines().removeIndex(mRemovedLineIdx);
+        if (editor().currentLineIdx() == editor().lines().size) {
+            editor().setCurrentLineIdx(editor().currentLineIdx() - 1);
+        }
+        editor().markNeedSave();
+    }
+
+    @Override
+    public boolean mergeWith(EditorAction other) {
+        return false;
+    }
+}

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/Editor.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/Editor.java
@@ -18,24 +18,23 @@
  */
 package com.agateau.pixelwheels.tools.trackeditor;
 
-/** Represents an action modifying the track */
-public abstract class EditorAction {
-    private final Editor mEditor;
+import com.agateau.pixelwheels.map.LapPositionTableIO;
+import com.badlogic.gdx.utils.Array;
 
-    public EditorAction(Editor editor) {
-        mEditor = editor;
-    }
+public interface Editor {
+    void markNeedSave();
 
-    public Editor editor() {
-        return mEditor;
-    }
+    Array<LapPositionTableIO.Line> lines();
 
-    public abstract void undo();
+    int currentLineIdx();
 
-    public abstract void redo();
+    void setCurrentLineIdx(int idx);
 
-    /**
-     * Returns true if @p other can be merged into this, instead of being added to the undo stack
-     */
-    public abstract boolean mergeWith(EditorAction other);
+    boolean isP1Selected();
+
+    boolean isP2Selected();
+
+    void setP1Selected(boolean selected);
+
+    void setP2Selected(boolean selected);
 }

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/EditorActionStack.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/EditorActionStack.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.pixelwheels.tools.trackeditor;
+
+import com.badlogic.gdx.utils.Array;
+
+class EditorActionStack {
+    private final Array<EditorAction> mActions = new Array<>();
+
+    public void add(EditorAction action) {
+        action.redo();
+        if (!mActions.isEmpty()) {
+            EditorAction lastAction = mActions.get(mActions.size - 1);
+            if (lastAction.mergeWith(action)) {
+                return;
+            }
+        }
+        mActions.add(action);
+    }
+
+    public void undo() {
+        if (mActions.isEmpty()) {
+            return;
+        }
+        EditorAction action = mActions.pop();
+        action.undo();
+    }
+}

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/EditorActionStack.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/EditorActionStack.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.utils.Array;
 
 class EditorActionStack {
     private final Array<EditorAction> mActions = new Array<>();
+    int mNextIndex = 0;
 
     public void add(EditorAction action) {
         action.redo();
@@ -31,14 +32,26 @@ class EditorActionStack {
                 return;
             }
         }
+        if (mNextIndex < mActions.size) {
+            mActions.removeRange(mNextIndex, mActions.size - 1);
+        }
         mActions.add(action);
+        ++mNextIndex;
     }
 
     public void undo() {
-        if (mActions.isEmpty()) {
+        if (mNextIndex == 0) {
             return;
         }
-        EditorAction action = mActions.pop();
-        action.undo();
+        --mNextIndex;
+        mActions.get(mNextIndex).undo();
+    }
+
+    public void redo() {
+        if (mNextIndex == mActions.size) {
+            return;
+        }
+        mActions.get(mNextIndex).redo();
+        mNextIndex++;
     }
 }

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/InsertSectionAction.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/InsertSectionAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.pixelwheels.tools.trackeditor;
+
+import com.agateau.pixelwheels.map.LapPositionTableIO;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+
+class InsertSectionAction extends EditorAction {
+    private static final Vector2 NEW_DELTA = new Vector2(12, 12);
+
+    int mInsertedLineIdx = -1;
+
+    public InsertSectionAction(Editor editor) {
+        super(editor);
+    }
+
+    @Override
+    public void undo() {
+        editor().setCurrentLineIdx(mInsertedLineIdx - 1);
+        editor().lines().removeIndex(mInsertedLineIdx);
+        editor().markNeedSave();
+    }
+
+    @Override
+    public void redo() {
+        Array<LapPositionTableIO.Line> lines = editor().lines();
+        int currentLineIdx = editor().currentLineIdx();
+        LapPositionTableIO.Line current = lines.get(currentLineIdx);
+        if (currentLineIdx == lines.size - 1) {
+            LapPositionTableIO.Line newLine = new LapPositionTableIO.Line();
+            newLine.p1.set(current.p1).add(NEW_DELTA);
+            newLine.p2.set(current.p2).add(NEW_DELTA);
+            newLine.order = current.order + 1;
+            lines.add(newLine);
+        } else {
+            LapPositionTableIO.Line next = lines.get(currentLineIdx + 1);
+            LapPositionTableIO.Line newLine = new LapPositionTableIO.Line();
+            newLine.p1.set(current.p1).lerp(next.p1, 0.5f);
+            newLine.p2.set(current.p2).lerp(next.p2, 0.5f);
+            newLine.order = MathUtils.lerp(current.order, next.order, 0.5f);
+            lines.insert(currentLineIdx + 1, newLine);
+        }
+        mInsertedLineIdx = currentLineIdx + 1;
+        editor().setCurrentLineIdx(mInsertedLineIdx);
+        editor().markNeedSave();
+    }
+
+    @Override
+    public boolean mergeWith(EditorAction other) {
+        return false;
+    }
+}

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/MoveSelectionAction.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/MoveSelectionAction.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.pixelwheels.tools.trackeditor;
+
+import com.agateau.pixelwheels.map.LapPositionTableIO;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+
+class MoveSelectionAction extends EditorAction {
+    private static final float MOVE_UNIT = 1;
+
+    private final Vector2 mDelta = new Vector2();
+    private final Array<Vector2> mPoints = new Array<>(/*ordered=*/ false, 2);
+
+    public MoveSelectionAction(Editor editor, int dx, int dy) {
+        super(editor);
+        mPoints.clear();
+        LapPositionTableIO.Line line = editor().lines().get(editor().currentLineIdx());
+        if (editor.isP1Selected()) {
+            mPoints.add(line.p1);
+        }
+        if (editor.isP2Selected()) {
+            mPoints.add(line.p2);
+        }
+        mDelta.set(dx, dy).scl(MOVE_UNIT);
+    }
+
+    @Override
+    public void undo() {
+        for (Vector2 point : mPoints) {
+            point.sub(mDelta);
+        }
+        editor().markNeedSave();
+    }
+
+    @Override
+    public void redo() {
+        for (Vector2 point : mPoints) {
+            point.add(mDelta);
+        }
+        editor().markNeedSave();
+    }
+
+    @Override
+    public boolean mergeWith(EditorAction otherAction) {
+        if (!(otherAction instanceof MoveSelectionAction)) {
+            return false;
+        }
+        MoveSelectionAction other = (MoveSelectionAction) otherAction;
+        if (mPoints.size != other.mPoints.size) {
+            return false;
+        }
+        // Use identity because we want to know if the action affects the same line ends, not if
+        // the line ends are at the same position (they are not)
+        if (!mPoints.containsAll(other.mPoints, /* identity=*/ true)) {
+            return false;
+        }
+        mDelta.add(other.mDelta);
+        return true;
+    }
+}

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/README.md
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/README.md
@@ -18,7 +18,7 @@ It is a keyboard-driven application. Here are the keyboard shortcuts:
 - select only second point: F2
 - select both points: F3
 - save: Control + S
-- undo: Control + Z
+- undo, redo: Control + Z, Control + Shift + Z
 
 To move or scroll faster, hold Shift.
 

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditor.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditor.java
@@ -18,10 +18,13 @@
  */
 package com.agateau.pixelwheels.tools.trackeditor;
 
+import com.agateau.utils.FileUtils;
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 
 public class TrackEditor extends Game {
     private static class Args {
@@ -83,6 +86,20 @@ public class TrackEditor extends Game {
 
     @Override
     public void create() {
-        setScreen(new TrackEditorScreen(Gdx.files.absolute(mArgs.tmxFilePath)));
+        BitmapFont font = loadFont();
+        setScreen(new TrackEditorScreen(Gdx.files.absolute(mArgs.tmxFilePath), font));
+    }
+
+    private static BitmapFont loadFont() {
+        FreeTypeFontGenerator.FreeTypeFontParameter parameter =
+                new FreeTypeFontGenerator.FreeTypeFontParameter();
+        parameter.size = 12;
+        parameter.borderWidth = 1f;
+
+        FreeTypeFontGenerator generator =
+                new FreeTypeFontGenerator(FileUtils.assets("fonts/Xolonium-Regular.ttf"));
+        BitmapFont font = generator.generateFont(parameter);
+        generator.dispose();
+        return font;
     }
 }

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditor.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditor.java
@@ -18,25 +18,10 @@
  */
 package com.agateau.pixelwheels.tools.trackeditor;
 
-import com.agateau.libgdx.AgcTmxMapLoader;
-import com.agateau.pixelwheels.map.LapPosition;
-import com.agateau.pixelwheels.map.LapPositionTable;
-import com.agateau.pixelwheels.map.LapPositionTableIO;
-import com.agateau.utils.log.NLog;
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
-import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.OrthographicCamera;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.PixmapIO;
-import com.badlogic.gdx.graphics.glutils.FrameBuffer;
-import com.badlogic.gdx.maps.tiled.TiledMap;
-import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
-import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
-import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.utils.ScreenUtils;
 
 public class TrackEditor extends Game {
     private static class Args {
@@ -99,74 +84,5 @@ public class TrackEditor extends Game {
     @Override
     public void create() {
         setScreen(new TrackEditorScreen(Gdx.files.absolute(mArgs.tmxFilePath)));
-    }
-
-    public static void generateTable(FileHandle tmxFile, FileHandle tableFile) {
-        TiledMap map = new AgcTmxMapLoader().load(tmxFile.path());
-        LapPositionTable table = LapPositionTableIO.load(map);
-
-        NLog.i("Drawing map");
-        Pixmap pixmap = drawMap(map);
-        NLog.i("Drawing table");
-        drawTable(table, pixmap);
-        NLog.i("Saving PNG");
-        PixmapIO.writePNG(tableFile, pixmap);
-    }
-
-    private static Pixmap drawMap(TiledMap map) {
-        TiledMapTileLayer layer = (TiledMapTileLayer) map.getLayers().get(0);
-        int mapWidth = layer.getWidth() * layer.getTileWidth();
-        int mapHeight = layer.getHeight() * layer.getTileHeight();
-
-        FrameBuffer fbo =
-                new FrameBuffer(Pixmap.Format.RGB888, mapWidth, mapHeight, false /* hasDepth */);
-        OrthogonalTiledMapRenderer renderer = new OrthogonalTiledMapRenderer(map);
-
-        OrthographicCamera camera = new OrthographicCamera();
-        camera.setToOrtho(true /* yDown */, mapWidth, mapHeight);
-        renderer.setView(camera);
-
-        fbo.begin();
-        renderer.render();
-
-        return ScreenUtils.getFrameBufferPixmap(0, 0, mapWidth, mapHeight);
-    }
-
-    public static void drawTable(LapPositionTable table, Pixmap pixmap) {
-        int width = pixmap.getWidth();
-        int height = pixmap.getHeight();
-        for (int y = 0; y < height; ++y) {
-            int percent = 100 * y / (height - 1);
-            System.out.print("\r" + percent + "%");
-            for (int x = 0; x < width; ++x) {
-                LapPosition pos = table.get(x, y);
-                if (pos == null) {
-                    continue;
-                }
-                int r = (int) ((1 - Math.abs(pos.getCenterDistance())) * 255);
-                int g = pos.getSectionId() * 255 / table.getSectionCount();
-                int b = (int) (pos.getSectionDistance() * 255);
-                blendPixel(pixmap, x, height - 1 - y, r, g, b, 0.7f);
-            }
-        }
-        System.out.println();
-    }
-
-    private static void blendPixel(Pixmap pixmap, int x, int y, int r, int g, int b, float k) {
-        int mapColor = pixmap.getPixel(x, y);
-        int mapR = (mapColor & 0xff000000) >>> 24;
-        int mapG = (mapColor & 0xff0000) >>> 16;
-        int mapB = (mapColor & 0xff00) >>> 8;
-
-        int color = createPixelColor(lerpi(mapR, r, k), lerpi(mapG, g, k), lerpi(mapB, b, k));
-        pixmap.drawPixel(x, y, color);
-    }
-
-    private static int createPixelColor(int r, int g, int b) {
-        return (r << 24) | (g << 16) | (b << 8) | 0xff;
-    }
-
-    private static int lerpi(int from, int to, float progress) {
-        return (int) MathUtils.lerp(from, to, progress);
     }
 }

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditorScreen.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditorScreen.java
@@ -46,12 +46,13 @@ public class TrackEditorScreen extends StageScreen implements Editor {
     private final SpriteBatch mBatch = new SpriteBatch();
     private final OrthographicCamera mCamera = new OrthographicCamera();
     private final ShapeRenderer mShapeRenderer = new ShapeRenderer();
-    private final Array<EditorAction> mEditorActions = new Array<>();
     private final Vector2 mViewCenter = new Vector2();
 
     private OrthogonalTiledMapRenderer mRenderer;
     private Array<LapPositionTableIO.Line> mLines;
     private float mZoom = 1f;
+
+    private final EditorActionStack mActionStack = new EditorActionStack();
 
     private int mCurrentLineIdx = 0;
     private boolean mSelectP1 = true;
@@ -85,22 +86,11 @@ public class TrackEditorScreen extends StageScreen implements Editor {
     }
 
     private void addAction(EditorAction action) {
-        action.redo();
-        if (!mEditorActions.isEmpty()) {
-            EditorAction lastAction = mEditorActions.get(mEditorActions.size - 1);
-            if (lastAction.mergeWith(action)) {
-                return;
-            }
-        }
-        mEditorActions.add(action);
+        mActionStack.add(action);
     }
 
     private void undo() {
-        if (mEditorActions.isEmpty()) {
-            return;
-        }
-        EditorAction action = mEditorActions.pop();
-        action.undo();
+        mActionStack.undo();
     }
 
     private void act() {

--- a/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditorScreen.java
+++ b/tools/src/com/agateau/pixelwheels/tools/trackeditor/TrackEditorScreen.java
@@ -89,10 +89,6 @@ public class TrackEditorScreen extends StageScreen implements Editor {
         mActionStack.add(action);
     }
 
-    private void undo() {
-        mActionStack.undo();
-    }
-
     private void act() {
         boolean control =
                 Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT)
@@ -158,7 +154,11 @@ public class TrackEditorScreen extends StageScreen implements Editor {
             doSave();
         }
         if (Gdx.input.isKeyJustPressed(Input.Keys.Z) && control) {
-            undo();
+            if (shift) {
+                mActionStack.redo();
+            } else {
+                mActionStack.undo();
+            }
         }
         save();
     }


### PR DESCRIPTION
- Implement redo, uses Shift+Ctrl+Z
- Draw the point number near selected points
