### PR TITLE
Always draw the mine shadow when attached

### DIFF
--- a/core/src/com/agateau/pixelwheels/bonus/Mine.java
+++ b/core/src/com/agateau/pixelwheels/bonus/Mine.java
@@ -164,8 +164,8 @@ public class Mine extends GameObjectAdapter
         mBodyRegionDrawer.setBatch(batch);
 
         Material material = mGameWorld.getTrack().getMaterialAt(getPosition());
-        boolean drawShadow = !material.isWater();
         boolean hasBeenDropped = mJoint == null;
+        boolean drawShadow = !hasBeenDropped || !material.isWater();
         if (hasBeenDropped) {
             switch (material) {
                 case WATER:


### PR DESCRIPTION
Fixes regression where the mine shadow would disappear when driving over
water.
