### PR TITLE
Sort languages

### DIFF
--- a/android/assets/po/bn.po
+++ b/android/assets/po/bn.po
@@ -3,17 +3,17 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Oymate, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-05-15 00:07+0200\n"
-       "Last-Translator: Oymate\n"
-       "Language-Team: Bengali\n"
-       "Language: bn\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=2; plural=n > 1;\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-05-15 00:07+0200\n"
+        "Last-Translator: Oymate\n"
+        "Language-Team: Bengali\n"
+        "Language: bn\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -82,7 +82,7 @@ msgstr  "কোড"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "অরেলিয়েন গাটেউ"
 
@@ -207,32 +207,33 @@ msgid   "Translations"
 msgstr  "অনুবাদ"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "ফরাসি:"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  ""
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  ""
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "স্পেনীয়:"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "ক্লারা গাটেই"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "ফরাসি:"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -251,20 +252,19 @@ msgid   "Nickoriginal"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "স্পেনীয়:"
+msgid   "Bengali:"
+msgstr  ""
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "ক্লারা গাটেই"
+msgid   "Oymate"
+msgstr  ""
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
+msgid   "Chinese:"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
+msgid   "Lu Xu"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:89
@@ -572,7 +572,7 @@ msgstr  ""
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "#"
 
@@ -584,19 +584,19 @@ msgstr  "সর্বোত্তম দৌড়"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "দৌড়বিদ"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "মোট সময়"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "পয়েন্ট"
 
@@ -619,7 +619,7 @@ msgstr  "কমপক্ষে ৩য় হও %s প্রতিযোগিত�
 msgid   "Finish first at %s championship"
 msgstr  "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 #, fuzzy
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
@@ -839,38 +839,38 @@ msgid   "OPEN LOG FILE FOLDER"
 msgstr  "লগ বা সূচী ফাইলের ফোল্ডার খুঁজে বের করো"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Police"
-#~ msgstr  "পোলিশ"
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "পোলিশ"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Red"
-#~ msgstr  "প্রস্তুত!"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "প্রস্তুত!"
 
 #, fuzzy
-#~ msgid   "Down | Brake:"
-#~ msgstr  "ব্রেক:"
+#~ msgid        "Down | Brake:"
+#~ msgstr       "ব্রেক:"
 
 #, fuzzy
-#~ msgid   "Left | Steer left:"
-#~ msgstr  "বামে যাও:"
+#~ msgid        "Left | Steer left:"
+#~ msgstr       "বামে যাও:"
 
 #, fuzzy
-#~ msgid   "Right | Steer right:"
-#~ msgstr  "ডানে যাও:"
+#~ msgid        "Right | Steer right:"
+#~ msgstr       "ডানে যাও:"
 
-#~ msgid   "Finished!"
-#~ msgstr  "সম্পন্ন!"
+#~ msgid        "Finished!"
+#~ msgstr       "সম্পন্ন!"
 
-#~ msgid   "Beta Testers"
-#~ msgstr  "পরীক্ষামূলক ব্যবহারকারী"
+#~ msgid        "Beta Testers"
+#~ msgstr       "পরীক্ষামূলক ব্যবহারকারী"
 
-#~ msgid   "(thank you!)"
-#~ msgstr  "(ধন্যবাদ!)"
+#~ msgid        "(thank you!)"
+#~ msgstr       "(ধন্যবাদ!)"
 
-#~ msgid   "OFF"
-#~ msgstr  "বন্ধ"
+#~ msgid        "OFF"
+#~ msgstr       "বন্ধ"
 
-#~ msgid   "ON"
-#~ msgstr  "চালু"
+#~ msgid        "ON"
+#~ msgstr       "চালু"

--- a/android/assets/po/de.po
+++ b/android/assets/po/de.po
@@ -1,16 +1,16 @@
 # Christian Schrötter <cs@fnx.li>, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-06-14 13:18+0200\n"
-       "Last-Translator: Christian Schrötter <cs@fnx.li>\n"
-       "Language-Team: German\n"
-       "Language: de_DE\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-06-14 13:18+0200\n"
+        "Last-Translator: Christian Schrötter <cs@fnx.li>\n"
+        "Language-Team: German\n"
+        "Language: de_DE\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -79,7 +79,7 @@ msgstr  "Programmierung"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -204,32 +204,33 @@ msgid   "Translations"
 msgstr  "Übersetzungen"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "Bengalisch:"
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "Chinesisch:"
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "Französisch:"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  "Deutsch:"
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  "Christian Schrötter"
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "Spanisch:"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  "Baskisch:"
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  "Josu Igoa"
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "Französisch:"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -248,21 +249,20 @@ msgid   "Nickoriginal"
 msgstr  "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "Spanisch:"
+msgid   "Bengali:"
+msgstr  "Bengalisch:"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  "Baskisch:"
+msgid   "Chinese:"
+msgstr  "Chinesisch:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -566,7 +566,7 @@ msgstr  "Beeindruckend!"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "#"
 
@@ -578,19 +578,19 @@ msgstr  "Schnellste Runde"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "Rennfahrer"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "Gesamtzeit"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "Punkte"
 
@@ -613,7 +613,7 @@ msgstr  "Rang 3 oder besser bei der %s Meisterschaft"
 msgid   "Finish first at %s championship"
 msgstr  "Rang 3 oder besser bei der %s Meisterschaft"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"

--- a/android/assets/po/es.po
+++ b/android/assets/po/es.po
@@ -3,17 +3,17 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Clara Gâteau, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-05-15 11:49+0100\n"
-       "Last-Translator: Clara Gâteau\n"
-       "Language-Team: Spanish\n"
-       "Language: es\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-05-15 11:49+0100\n"
+        "Last-Translator: Clara Gâteau\n"
+        "Language-Team: Spanish\n"
+        "Language: es\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -82,7 +82,7 @@ msgstr  "Código"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -207,32 +207,33 @@ msgid   "Translations"
 msgstr  "Traducciones"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "Bengalí :"
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "Chino :"
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "Francés :"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  ""
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  ""
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "Español :"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "Francés :"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -251,21 +252,20 @@ msgid   "Nickoriginal"
 msgstr  "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "Español :"
+msgid   "Bengali:"
+msgstr  "Bengalí :"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  ""
+msgid   "Chinese:"
+msgstr  "Chino :"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  ""
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -569,7 +569,7 @@ msgstr  "Impresionante !"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "N°"
 
@@ -581,19 +581,19 @@ msgstr  "Mejor vuelta"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "Piloto"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "Tiempo total"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "Puntos"
 
@@ -616,7 +616,7 @@ msgstr  "Llegar tercero o mejor al campeonato %s"
 msgid   "Finish first at %s championship"
 msgstr  "Llegar tercero o mejor al campeonato %s"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"
@@ -831,29 +831,29 @@ msgid   "OPEN LOG FILE FOLDER"
 msgstr  "FICHERO DE LOG"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Police"
-#~ msgstr  "Polaco :"
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "Polaco :"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Red"
-#~ msgstr  "Listo !"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "Listo !"
 
 #, fuzzy
-#~ msgid   "Down | Brake:"
-#~ msgstr  "Frenar :"
+#~ msgid        "Down | Brake:"
+#~ msgstr       "Frenar :"
 
 #, fuzzy
-#~ msgid   "Left | Steer left:"
-#~ msgstr  "Girar a la izquierda :"
+#~ msgid        "Left | Steer left:"
+#~ msgstr       "Girar a la izquierda :"
 
 #, fuzzy
-#~ msgid   "Right | Steer right:"
-#~ msgstr  "Girar a la derecha :"
+#~ msgid        "Right | Steer right:"
+#~ msgstr       "Girar a la derecha :"
 
-#~ msgid   "OFF"
-#~ msgstr  "No"
+#~ msgid        "OFF"
+#~ msgstr       "No"
 
-#~ msgid   "ON"
-#~ msgstr  "Sí"
+#~ msgid        "ON"
+#~ msgstr       "Sí"

--- a/android/assets/po/eu.po
+++ b/android/assets/po/eu.po
@@ -3,17 +3,17 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Josu Igoa, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-05-15 11:49+0100\n"
-       "Last-Translator: Josu Igoa\n"
-       "Language-Team: Basque\n"
-       "Language: eu\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-05-15 11:49+0100\n"
+        "Last-Translator: Josu Igoa\n"
+        "Language-Team: Basque\n"
+        "Language: eu\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -82,7 +82,7 @@ msgstr  "Kodea"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -207,32 +207,33 @@ msgid   "Translations"
 msgstr  "Itzulpenak"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "Bengalera:"
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "Txinera:"
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "Frantsesa:"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  "Alemaniera:"
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  "Christian Schrötter"
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "Espainiera:"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  "Euskara:"
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  "Josu Igoa"
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "Frantsesa:"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -251,21 +252,20 @@ msgid   "Nickoriginal"
 msgstr  "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "Espainiera:"
+msgid   "Bengali:"
+msgstr  "Bengalera:"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  "Euskara:"
+msgid   "Chinese:"
+msgstr  "Txinera:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -569,7 +569,7 @@ msgstr  "Izugarria!"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  ""
 
@@ -581,19 +581,19 @@ msgstr  "Itzuli onena"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "Gidaria"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "Denbora guztira"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "Puntuak"
 
@@ -616,7 +616,7 @@ msgstr  "Bigarren edo postu hobean buka ezazu %s txapelketa"
 msgid   "Finish first at %s championship"
 msgstr  "Lehenengo postuan buka ezazu %s txapelketa"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"
@@ -829,11 +829,11 @@ msgid   "OPEN LOG FILE FOLDER"
 msgstr  "LOG-EN KARPETA IREKI"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Police"
-#~ msgstr  "Polizia"
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "Polizia"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Red"
-#~ msgstr  "Gorria"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "Gorria"

--- a/android/assets/po/fr.po
+++ b/android/assets/po/fr.po
@@ -1,874 +1,870 @@
 # Aurélien Gâteau <mail@agateau.com>, 2022.
-msgid ""
-msgstr ""
-"Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2022-06-21 09:05+0200\n"
-"Last-Translator: Aurélien Gâteau <mail@agateau.com>\n"
-"Language-Team: French\n"
-"Language: fr_FR\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"POT-Creation-Date: \n"
-"X-Generator: Poedit 2.3\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "POT-Creation-Date: \n"
+        "PO-Revision-Date: 2022-06-21 09:05+0200\n"
+        "Last-Translator: Aurélien Gâteau <mail@agateau.com>\n"
+        "Language-Team: French\n"
+        "Language: fr_FR\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+        "X-Generator: Poedit 2.3\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid "Country Life"
-msgstr "La vie à la campagne"
+msgid   "Country Life"
+msgstr  "La vie à la campagne"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid "Welcome!"
-msgstr "Bienvenue !"
+msgid   "Welcome!"
+msgstr  "Bienvenue !"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid "River"
-msgstr "Rivière"
+msgid   "River"
+msgstr  "Rivière"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid "Flood"
-msgstr "Inondation"
+msgid   "Flood"
+msgstr  "Inondation"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid "Square Mountains"
-msgstr "Les Monts Carrés"
+msgid   "Square Mountains"
+msgstr  "Les Monts Carrés"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid "Let it snow"
-msgstr "Vive le vent d'hiver"
+msgid   "Let it snow"
+msgstr  "Vive le vent d'hiver"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid "Don't slip!"
-msgstr "J'ai glissé, chef !"
+msgid   "Don't slip!"
+msgstr  "J'ai glissé, chef !"
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid "Pix Cities"
-msgstr "La cité des pixels"
+msgid   "Pix Cities"
+msgstr  "La cité des pixels"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid "Blocky Town"
-msgstr "Blocville"
+msgid   "Blocky Town"
+msgstr  "Blocville"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid "Tiny sur Mer"
-msgstr "Tiny sur Mer"
+msgid   "Tiny sur Mer"
+msgstr  "Tiny sur Mer"
 
 #: android/assets/screens/credits.gdxui:6
-msgid "Pixel Wheels"
-msgstr "Pixel Wheels"
+msgid   "Pixel Wheels"
+msgstr  "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid "An open-source racing game"
-msgstr "Un jeu de course open-source"
+msgid   "An open-source racing game"
+msgstr  "Un jeu de course open-source"
 
 #: android/assets/screens/credits.gdxui:10
-msgid "Code"
-msgstr "Code"
+msgid   "Code"
+msgstr  "Code"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
-msgid "Aurélien Gâteau"
-msgstr "Aurélien Gâteau"
+#: android/assets/screens/credits.gdxui:75
+msgid   "Aurélien Gâteau"
+msgstr  "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid "Pixels"
-msgstr "Pixels"
+msgid   "Pixels"
+msgstr  "Pixels"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:95
-msgid "Antonin Gâteau"
-msgstr "Antonin Gâteau"
+msgid   "Antonin Gâteau"
+msgstr  "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid "Music"
-msgstr "Musique"
+msgid   "Music"
+msgstr  "Musique"
 
 #: android/assets/screens/credits.gdxui:21
-msgid "Menu:"
-msgstr "Menu :"
+msgid   "Menu:"
+msgstr  "Menu :"
 
 #: android/assets/screens/credits.gdxui:22
-msgid "\"Lightspeed\""
-msgstr "\"Lightspeed\""
+msgid   "\"Lightspeed\""
+msgstr  "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid "Thomas Tripon"
-msgstr "Thomas Tripon"
+msgid   "Thomas Tripon"
+msgstr  "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid "Victory:"
-msgstr "Victoire :"
+msgid   "Victory:"
+msgstr  "Victoire :"
 
 #: android/assets/screens/credits.gdxui:26
-msgid "\"Core Descent (16-bit) v0.9\""
-msgstr "\"Core Descent (16-bit) v0.9\""
+msgid   "\"Core Descent (16-bit) v0.9\""
+msgstr  "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid "FoxSynergy"
-msgstr "FoxSynergy"
+msgid   "FoxSynergy"
+msgstr  "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid "Country Life championship:"
-msgstr "Championnat Country Life :"
+msgid   "Country Life championship:"
+msgstr  "Championnat Country Life :"
 
 #: android/assets/screens/credits.gdxui:30
-msgid "\"Cosmo Blast v1.0\""
-msgstr "\"Cosmo Blast v1.0\""
+msgid   "\"Cosmo Blast v1.0\""
+msgstr  "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid "Square Mountains championship:"
-msgstr "Championnat Square Mountains :"
+msgid   "Square Mountains championship:"
+msgstr  "Championnat Square Mountains :"
 
 #: android/assets/screens/credits.gdxui:34
-msgid "\"Lunar Harvest v1.0\""
-msgstr "\"Lunar Harvest v1.0\""
+msgid   "\"Lunar Harvest v1.0\""
+msgstr  "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid "Pix Cities championship:"
-msgstr "Championnat Pix Cities :"
+msgid   "Pix Cities championship:"
+msgstr  "Championnat Pix Cities :"
 
 #: android/assets/screens/credits.gdxui:38
-msgid "\"Bouncing Baal v0.95\""
-msgstr "\"Bouncing Baal v0.95\""
+msgid   "\"Bouncing Baal v0.95\""
+msgstr  "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid "Sound Effects"
-msgstr "Effets sonores"
+msgid   "Sound Effects"
+msgstr  "Effets sonores"
 
 #: android/assets/screens/credits.gdxui:43
-msgid "\"Car tire squeal skid loop\""
-msgstr "\"Car tire squeal skid loop\""
+msgid   "\"Car tire squeal skid loop\""
+msgstr  "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid "Tom Haigh"
-msgstr "Tom Haigh"
+msgid   "Tom Haigh"
+msgstr  "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid "\"Racing car engine sound loops\""
-msgstr "\"Racing car engine sound loops\""
+msgid   "\"Racing car engine sound loops\""
+msgstr  "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid "domasx2"
-msgstr "domasx2"
+msgid   "domasx2"
+msgstr  "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid "Other sound effects"
-msgstr "Autres effets sonores"
+msgid   "Other sound effects"
+msgstr  "Autres effets sonores"
 
 #: android/assets/screens/credits.gdxui:52
-msgid "Fonts"
-msgstr "Polices"
+msgid   "Fonts"
+msgstr  "Polices"
 
 #: android/assets/screens/credits.gdxui:54
-msgid "Xolonium"
-msgstr "Xolonium"
+msgid   "Xolonium"
+msgstr  "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid "Severin Meyer"
-msgstr "Severin Meyer"
+msgid   "Severin Meyer"
+msgstr  "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid "Kwajong"
-msgstr "Kwajong"
+msgid   "Kwajong"
+msgstr  "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid "Tup Wanders"
-msgstr "Tup Wanders"
+msgid   "Tup Wanders"
+msgstr  "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid "Noto"
-msgstr "Noto"
+msgid   "Noto"
+msgstr  "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid "Google"
-msgstr "Google"
+msgid   "Google"
+msgstr  "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid "Translations"
-msgstr "Traductions"
+msgid   "Translations"
+msgstr  "Traductions"
 
 #: android/assets/screens/credits.gdxui:65
-msgid "Bengali:"
-msgstr "Bengali :"
+msgid   "German:"
+msgstr  "Allemand :"
 
 #: android/assets/screens/credits.gdxui:66
-msgid "Oymate"
-msgstr "Oymate"
+msgid   "Christian Schrötter"
+msgstr  "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid "Chinese:"
-msgstr "Chinois :"
+msgid   "Spanish:"
+msgstr  "Espagnol :"
 
 #: android/assets/screens/credits.gdxui:69
-msgid "Lu Xu"
-msgstr "Lu Xu"
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid "French:"
-msgstr "Français :"
+msgid   "Basque:"
+msgstr  "Basque :"
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid "German:"
-msgstr "Allemand :"
-
-#: android/assets/screens/credits.gdxui:75
-msgid "Christian Schrötter"
-msgstr "Christian Schrötter"
+msgid   "French:"
+msgstr  "Français :"
 
 #: android/assets/screens/credits.gdxui:77
-msgid "Polish:"
-msgstr "Polonais:"
+msgid   "Polish:"
+msgstr  "Polonais:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid "PandaCoderPL"
-msgstr "PandaCoderPL"
+msgid   "PandaCoderPL"
+msgstr  "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
-msgid "Russian:"
-msgstr "Russe :"
+msgid   "Russian:"
+msgstr  "Russe :"
 
 #: android/assets/screens/credits.gdxui:81
-msgid "Nickoriginal"
-msgstr "Nickoriginal"
+msgid   "Nickoriginal"
+msgstr  "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:83
-msgid "Spanish:"
-msgstr "Espagnol :"
+msgid   "Bengali:"
+msgstr  "Bengali :"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid "Clara Gâteau"
-msgstr "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid "Basque:"
-msgstr "Basque :"
+msgid   "Chinese:"
+msgstr  "Chinois :"
 
 #: android/assets/screens/credits.gdxui:87
-msgid "Josu Igoa"
-msgstr "Josu Igoa"
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
-msgid "Video Editing"
-msgstr "Édition vidéo"
+msgid   "Video Editing"
+msgstr  "Édition vidéo"
 
 #: android/assets/screens/credits.gdxui:93
-msgid "Special Thanks"
-msgstr "Merci à"
+msgid   "Special Thanks"
+msgstr  "Merci à"
 
 #: android/assets/screens/credits.gdxui:96
-msgid "Guillaume Roche"
-msgstr "Guillaume Roche"
+msgid   "Guillaume Roche"
+msgstr  "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:97
-msgid "Ethan Chapman"
-msgstr "Ethan Chapman"
+msgid   "Ethan Chapman"
+msgstr  "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:98
-msgid "All bug reporters"
-msgstr "Les rapporteurs de bug"
+msgid   "All bug reporters"
+msgstr  "Les rapporteurs de bug"
 
 #: android/assets/screens/credits.gdxui:99
-msgid "All supporters on Patreon, Ko-fi and Paypal"
-msgstr "Les soutiens sur Patreon, Ko-fi et Paypal"
+msgid   "All supporters on Patreon, Ko-fi and Paypal"
+msgstr  "Les soutiens sur Patreon, Ko-fi et Paypal"
 
 #: android/assets/screens/credits.gdxui:101
-msgid "Made with"
-msgstr "Créé avec"
+msgid   "Made with"
+msgstr  "Créé avec"
 
 #: android/assets/screens/credits.gdxui:103
-msgid "LibGDX"
-msgstr "LibGDX"
+msgid   "LibGDX"
+msgstr  "LibGDX"
 
 #: android/assets/screens/credits.gdxui:104
-msgid "Tiled"
-msgstr "Tiled"
+msgid   "Tiled"
+msgstr  "Tiled"
 
 #: android/assets/screens/credits.gdxui:105
-msgid "Aseprite"
-msgstr "Aseprite"
+msgid   "Aseprite"
+msgstr  "Aseprite"
 
 #: android/assets/screens/credits.gdxui:106
-msgid "SFXR Qt"
-msgstr "SFXR Qt"
+msgid   "SFXR Qt"
+msgstr  "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:107
-msgid "Android Studio"
-msgstr "Android Studio"
+msgid   "Android Studio"
+msgstr  "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid "Settings affecting game play have been modified, scores won't be saved"
-msgstr "Des réglages affectant la jouabilité ont été modifiés, les scores ne seront pas sauvegardés"
+msgid   "Settings affecting game play have been modified, scores won't be saved"
+msgstr  "Des réglages affectant la jouabilité ont été modifiés, les scores ne seront pas sauvegardés"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid "RESTART"
-msgstr "RECOMMENCER"
+msgid   "RESTART"
+msgstr  "RECOMMENCER"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid "BACK TO MENU"
-msgstr "RETOUR"
+msgid   "BACK TO MENU"
+msgstr  "RETOUR"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid "CONTINUE"
-msgstr "CONTINUER"
+msgid   "CONTINUE"
+msgstr  "CONTINUER"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid "Gamepad config"
-msgstr "Configuration manette"
+msgid   "Gamepad config"
+msgstr  "Configuration manette"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid "Trigger:"
-msgstr "Activer :"
+msgid   "Trigger:"
+msgstr  "Activer :"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid "Back/reverse:"
-msgstr "Retour / marche arrière :"
+msgid   "Back/reverse:"
+msgstr  "Retour / marche arrière :"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid "Keyboard config"
-msgstr "Configuration du clavier"
+msgid   "Keyboard config"
+msgstr  "Configuration du clavier"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid "ONE PLAYER"
-msgstr "UN JOUEUR"
+msgid   "ONE PLAYER"
+msgstr  "UN JOUEUR"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid "MULTI PLAYER"
-msgstr "MULTI-JOUEURS"
+msgid   "MULTI PLAYER"
+msgstr  "MULTI-JOUEURS"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid "QUICK RACE"
-msgstr "COURSE RAPIDE"
+msgid   "QUICK RACE"
+msgstr  "COURSE RAPIDE"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid "CHAMPIONSHIP"
-msgstr "CHAMPIONNAT"
+msgid   "CHAMPIONSHIP"
+msgstr  "CHAMPIONNAT"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid "SETTINGS"
-msgstr "CONFIGURATION"
+msgid   "SETTINGS"
+msgstr  "CONFIGURATION"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid "QUIT"
-msgstr "QUITTER"
+msgid   "QUIT"
+msgstr  "QUITTER"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid "Select Your Vehicles"
-msgstr "Choisissez vos véhicules"
+msgid   "Select Your Vehicles"
+msgstr  "Choisissez vos véhicules"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid "Ready!"
-msgstr "Prêt !"
+msgid   "Ready!"
+msgstr  "Prêt !"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid "Some gamepads are missing"
-msgstr "Certaines manettes sont manquantes"
+msgid   "Some gamepads are missing"
+msgstr  "Certaines manettes sont manquantes"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid "Paused"
-msgstr "Pause"
+msgid   "Paused"
+msgstr  "Pause"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid "RESUME"
-msgstr "CONTINUER"
+msgid   "RESUME"
+msgstr  "CONTINUER"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid "QUIT TO MENU"
-msgstr "RETOUR AU MENU"
+msgid   "QUIT TO MENU"
+msgstr  "RETOUR AU MENU"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid "Select Championship"
-msgstr "Choisissez un championnat"
+msgid   "Select Championship"
+msgstr  "Choisissez un championnat"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid "Select Game Mode"
-msgstr "Choisissez le mode de jeu"
+msgid   "Select Game Mode"
+msgstr  "Choisissez le mode de jeu"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid "Select Language"
-msgstr "Sélectionnez la langue"
+msgid   "Select Language"
+msgstr  "Sélectionnez la langue"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid "Select Track"
-msgstr "Choisissez une piste"
+msgid   "Select Track"
+msgstr  "Choisissez une piste"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid "Best Lap"
-msgstr "Meilleur tour"
+msgid   "Best Lap"
+msgstr  "Meilleur tour"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid "Best Total"
-msgstr "Meilleur temps total"
+msgid   "Best Total"
+msgstr  "Meilleur temps total"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid "Select Your Vehicle"
-msgstr "Choisissez votre véhicule"
+msgid   "Select Your Vehicle"
+msgstr  "Choisissez votre véhicule"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid "2-Deuch"
-msgstr "2-Deuch"
+msgid   "2-Deuch"
+msgstr  "2-Deuch"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid "Ant On-1"
-msgstr "Ant On-1"
+msgid   "Ant On-1"
+msgstr  "Ant On-1"
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid "Dark M"
-msgstr "Dark M"
+msgid   "Dark M"
+msgstr  "Dark M"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid "Harvester"
-msgstr "Moiss-batt"
+msgid   "Harvester"
+msgstr  "Moiss-batt"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid "Jeep"
-msgstr "Jeep"
+msgid   "Jeep"
+msgstr  "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid "Miramar"
-msgstr "Miramar"
+msgid   "Miramar"
+msgstr  "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid "Pickup"
-msgstr "Pickup"
+msgid   "Pickup"
+msgstr  "Pickup"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid "Highway Patrol"
-msgstr "Highway Patrol"
+msgid   "Highway Patrol"
+msgstr  "Highway Patrol"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid "Red Lightning"
-msgstr "Red Lightning"
+msgid   "Red Lightning"
+msgstr  "Red Lightning"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid "Roadster"
-msgstr "Roadster"
+msgid   "Roadster"
+msgstr  "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid "Rocket"
-msgstr "Roquette"
+msgid   "Rocket"
+msgstr  "Roquette"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid "Santa Truck"
-msgstr "Camion de Noël"
+msgid   "Santa Truck"
+msgstr  "Camion de Noël"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid "Share via"
-msgstr "Partager via"
+msgid   "Share via"
+msgstr  "Partager via"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid "Hit a bug? Use this button to report it."
-msgstr "Vous avez trouvé un bug ? Utiliser ce bouton pour le rapporter."
+msgid   "Hit a bug? Use this button to report it."
+msgstr  "Vous avez trouvé un bug ? Utiliser ce bouton pour le rapporter."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid "REPORT BUG"
-msgstr "RAPPORTER UN BUG"
+msgid   "REPORT BUG"
+msgstr  "RAPPORTER UN BUG"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid "Hit one vehicle with a missile"
-msgid_plural "Hit %# vehicles with a missile"
-msgstr[0] "Toucher un véhicule avec un missile"
-msgstr[1] "Toucher %# véhicules avec un missile"
+msgid   "Hit one vehicle with a missile"
+msgid_plural    "Hit %# vehicles with a missile"
+msgstr[0]       "Toucher un véhicule avec un missile"
+msgstr[1]       "Toucher %# véhicules avec un missile"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid "Leave road one time"
-msgid_plural "Leave road %# times"
-msgstr[0] "Quitter la route une fois"
-msgstr[1] "Quitter la route %# fois"
+msgid   "Leave road one time"
+msgid_plural    "Leave road %# times"
+msgstr[0]       "Quitter la route une fois"
+msgstr[1]       "Quitter la route %# fois"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid "Pick one bonus"
-msgid_plural "Pick %# bonuses"
-msgstr[0] "Attraper un bonus"
-msgstr[1] "Attraper %# bonus"
+msgid   "Pick one bonus"
+msgid_plural    "Pick %# bonuses"
+msgstr[0]       "Attraper un bonus"
+msgstr[1]       "Attraper %# bonus"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid "Gamepad"
-msgstr "Manette"
+msgid   "Gamepad"
+msgstr  "Manette"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid "Keyboard"
-msgstr "Clavier"
+msgid   "Keyboard"
+msgstr  "Clavier"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid "Pie buttons"
-msgstr "Boutons en arc"
+msgid   "Pie buttons"
+msgstr  "Boutons en arc"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid "Side buttons"
-msgstr "Boutons sur les côtés"
+msgid   "Side buttons"
+msgstr  "Boutons sur les côtés"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid "Championship Rankings"
-msgstr "Classement du championnat"
+msgid   "Championship Rankings"
+msgstr  "Classement du championnat"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid "Race Results"
-msgstr "Résultats de la course"
+msgid   "Race Results"
+msgstr  "Résultats de la course"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid "Congratulations, great race!"
-msgstr "Félicitations, superbe course !"
+msgid   "Congratulations, great race!"
+msgstr  "Félicitations, superbe course !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid "You've got some serious driving skills!"
-msgstr "Vous êtes un sacré pilote !"
+msgid   "You've got some serious driving skills!"
+msgstr  "Vous êtes un sacré pilote !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid "You're a champ!"
-msgstr "Champion !"
+msgid   "You're a champ!"
+msgstr  "Champion !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid "Congrats for this performance!"
-msgstr "Bravo pour cette performance !"
+msgid   "Congrats for this performance!"
+msgstr  "Bravo pour cette performance !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid "Impressive!"
-msgstr "Impressionnant !"
+msgid   "Impressive!"
+msgstr  "Impressionnant !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
-msgid "#"
-msgstr "N°"
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
+msgid   "#"
+msgstr  "N°"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid "Best lap"
-msgstr "Meilleur tour"
+msgid   "Best lap"
+msgstr  "Meilleur tour"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
-msgid "Racer"
-msgstr "Pilote"
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
+msgid   "Racer"
+msgstr  "Pilote"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
-msgid "Total time"
-msgstr "Temps total"
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
+msgid   "Total time"
+msgstr  "Temps total"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
-msgid "Points"
-msgstr "Points"
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
+msgid   "Points"
+msgstr  "Points"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid "Race time"
-msgstr "Temps de course"
+msgid   "Race time"
+msgstr  "Temps de course"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
-msgid "Finish third or better at %s championship"
-msgstr "Arriver 3e ou mieux au championnat %s"
+msgid   "Finish third or better at %s championship"
+msgstr  "Arriver 3e ou mieux au championnat %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
-msgid "Finish second or better at %s championship"
-msgstr "Arriver 2e ou mieux au championnat %s"
+msgid   "Finish second or better at %s championship"
+msgstr  "Arriver 2e ou mieux au championnat %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
-msgid "Finish first at %s championship"
-msgstr "Arriver 1er au championnat %s"
+msgid   "Finish first at %s championship"
+msgstr  "Arriver 1er au championnat %s"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid ""
-"Championship\n"
-"Finished!"
-msgstr ""
-"Championnat\n"
-"terminé !"
+msgid   "Championship\n"
+        "Finished!"
+msgstr  "Championnat\n"
+        "terminé !"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid "About"
-msgstr "À propos"
+msgid   "About"
+msgstr  "À propos"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
-msgid "Pixel Wheels %s"
-msgstr "Pixel Wheels %s"
+msgid   "Pixel Wheels %s"
+msgstr  "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid "CREDITS"
-msgstr "CRÉDITS"
+msgid   "CREDITS"
+msgstr  "CRÉDITS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid ""
-"Pixel Wheels is free, but you can support its\n"
-"development in various ways."
-msgstr "Pixel Wheels est gratuit, mais vous pouvez soutenir son développement de plusieurs façons."
+msgid   "Pixel Wheels is free, but you can support its\n"
+        "development in various ways."
+msgstr  "Pixel Wheels est gratuit, mais vous pouvez soutenir son développement de plusieurs façons."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid "VISIT SUPPORT PAGE"
-msgstr "PAGE DE SOUTIEN"
+msgid   "VISIT SUPPORT PAGE"
+msgstr  "PAGE DE SOUTIEN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid "Learn more about Pixel Wheels"
-msgstr "En apprendre plus sur Pixel Wheels"
+msgid   "Learn more about Pixel Wheels"
+msgstr  "En apprendre plus sur Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid "VISIT WEB SITE"
-msgstr "SITE WEB"
+msgid   "VISIT WEB SITE"
+msgstr  "SITE WEB"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid "Under the hood"
-msgstr "Sous le capot"
+msgid   "Under the hood"
+msgstr  "Sous le capot"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr "Ces options sont surtout intéressantes pour le développement de Pixel Wheels, mais vous pouvez y faire un tour !"
+msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
+msgstr  "Ces options sont surtout intéressantes pour le développement de Pixel Wheels, mais vous pouvez y faire un tour !"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid "DEV. OPTIONS"
-msgstr "COIN DES DEVS"
+msgid   "DEV. OPTIONS"
+msgstr  "COIN DES DEVS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid "Controls"
-msgstr "Contrôles"
+msgid   "Controls"
+msgstr  "Contrôles"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
-msgid "Player #%d:"
-msgstr "Joueur n°%d :"
+msgid   "Player #%d:"
+msgstr  "Joueur n°%d :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid "Controls:"
-msgstr "Contrôles :"
+msgid   "Controls:"
+msgstr  "Contrôles :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid "General"
-msgstr "Général"
+msgid   "General"
+msgstr  "Général"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid "Language:"
-msgstr "Langue :"
+msgid   "Language:"
+msgstr  "Langue :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid "Audio"
-msgstr "Audio"
+msgid   "Audio"
+msgstr  "Audio"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid "Sound FX:"
-msgstr "Effets sonores :"
+msgid   "Sound FX:"
+msgstr  "Effets sonores :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid "Music:"
-msgstr "Musique :"
+msgid   "Music:"
+msgstr  "Musique :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid "Video"
-msgstr "Vidéo"
+msgid   "Video"
+msgstr  "Vidéo"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid "Fullscreen:"
-msgstr "Plein écran :"
+msgid   "Fullscreen:"
+msgstr  "Plein écran :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid "CONFIGURE"
-msgstr "CONFIGURER"
+msgid   "CONFIGURE"
+msgstr  "CONFIGURER"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid "Thank you for playing!"
-msgstr "Merci d'avoir joué !"
+msgid   "Thank you for playing!"
+msgstr  "Merci d'avoir joué !"
 
 #: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid "Press the gamepad key..."
-msgstr "Pressez une touche de la manette..."
+msgid   "Press the gamepad key..."
+msgstr  "Pressez une touche de la manette..."
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid "Brake"
-msgstr "Freiner"
+msgid   "Brake"
+msgstr  "Freiner"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid "Steer left"
-msgstr "Tourner à gauche"
+msgid   "Steer left"
+msgstr  "Tourner à gauche"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid "Steer right"
-msgstr "Tourner à droite"
+msgid   "Steer right"
+msgstr  "Tourner à droite"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid "Trigger"
-msgstr "Activer"
+msgid   "Trigger"
+msgstr  "Activer"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid "Up"
-msgstr "Haut"
+msgid   "Up"
+msgstr  "Haut"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid "Down"
-msgstr "Bas"
+msgid   "Down"
+msgstr  "Bas"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid "Left"
-msgstr "Gauche"
+msgid   "Left"
+msgstr  "Gauche"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid "Right"
-msgstr "Droite"
+msgid   "Right"
+msgstr  "Droite"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid "Activate"
-msgstr "Activer"
+msgid   "Activate"
+msgstr  "Activer"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid "Back"
-msgstr "Retour"
+msgid   "Back"
+msgstr  "Retour"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid "Missing"
-msgstr "Manquant"
+msgid   "Missing"
+msgstr  "Manquant"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid "OK"
-msgstr "OK"
+msgid   "OK"
+msgstr  "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
-msgid "Player #%d: %s"
-msgstr "Joueur n°%d : %s"
+msgid   "Player #%d: %s"
+msgstr  "Joueur n°%d : %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid "MAIN MENU"
-msgstr "MENU PRINCIPAL"
+msgid   "MAIN MENU"
+msgstr  "MENU PRINCIPAL"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid "[Locked]"
-msgstr "[Verrouillé]"
+msgid   "[Locked]"
+msgstr  "[Verrouillé]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid "CPU"
-msgstr "CPU"
+msgid   "CPU"
+msgstr  "CPU"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid "New vehicle unlocked!"
-msgstr "Nouveau véhicule débloqué !"
+msgid   "New vehicle unlocked!"
+msgstr  "Nouveau véhicule débloqué !"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid "New championship unlocked!"
-msgstr "Nouveau championnat débloqué !"
+msgid   "New championship unlocked!"
+msgstr  "Nouveau championnat débloqué !"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid "1st"
-msgstr "1er"
+msgid   "1st"
+msgstr  "1er"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid "2nd"
-msgstr "2e"
+msgid   "2nd"
+msgstr  "2e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid "3rd"
-msgstr "3e"
+msgid   "3rd"
+msgstr  "3e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid "4th"
-msgstr "4e"
+msgid   "4th"
+msgstr  "4e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid "5th"
-msgstr "5e"
+msgid   "5th"
+msgstr  "5e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid "6th"
-msgstr "6e"
+msgid   "6th"
+msgstr  "6e"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid "Need to file a bug report? Use this button to find the log file to attach."
-msgstr "Besoin de créer un rapport de bug ? Utilisez ce bouton pour trouver le fichier de log à attacher."
+msgid   "Need to file a bug report? Use this button to find the log file to attach."
+msgstr  "Besoin de créer un rapport de bug ? Utilisez ce bouton pour trouver le fichier de log à attacher."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid "OPEN LOG FILE FOLDER"
-msgstr "DOSSIER DES LOGS"
+msgid   "OPEN LOG FILE FOLDER"
+msgstr  "DOSSIER DES LOGS"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid "Police"
-#~ msgstr "Polonais:"
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "Polonais:"
 
-#~ msgctxt "vehicle"
-#~ msgid "Red"
-#~ msgstr "Rouge"
-
-#, fuzzy
-#~ msgid "Down | Brake:"
-#~ msgstr "Freiner :"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "Rouge"
 
 #, fuzzy
-#~ msgid "Left | Steer left:"
-#~ msgstr "Tourner à gauche :"
+#~ msgid        "Down | Brake:"
+#~ msgstr       "Freiner :"
 
 #, fuzzy
-#~ msgid "Right | Steer right:"
-#~ msgstr "Tourner à droite :"
+#~ msgid        "Left | Steer left:"
+#~ msgstr       "Tourner à gauche :"
 
-#~ msgid "OFF"
-#~ msgstr "Non"
+#, fuzzy
+#~ msgid        "Right | Steer right:"
+#~ msgstr       "Tourner à droite :"
 
-#~ msgid "ON"
-#~ msgstr "Oui"
+#~ msgid        "OFF"
+#~ msgstr       "Non"
 
-#~ msgid "Finished!"
-#~ msgstr "terminé !"
+#~ msgid        "ON"
+#~ msgstr       "Oui"
 
-#~ msgid "Beta Testers"
-#~ msgstr "Bêta testeurs"
+#~ msgid        "Finished!"
+#~ msgstr       "terminé !"
 
-#~ msgid "(thank you!)"
-#~ msgstr "(merci !)"
+#~ msgid        "Beta Testers"
+#~ msgstr       "Bêta testeurs"
 
-#~ msgid "Internal"
-#~ msgstr "Interne"
+#~ msgid        "(thank you!)"
+#~ msgstr       "(merci !)"
 
-#~ msgid "Audio & Video"
-#~ msgstr "Audio & Vidéo"
+#~ msgid        "Internal"
+#~ msgstr       "Interne"
 
-#~ msgid "Others"
-#~ msgstr "Autres"
+#~ msgid        "Audio & Video"
+#~ msgstr       "Audio & Vidéo"
 
-#~ msgid "Player %d:"
-#~ msgstr "Joueur n°%d  :"
+#~ msgid        "Others"
+#~ msgstr       "Autres"
 
-#~ msgid "%s:"
-#~ msgstr "%s :"
+#~ msgid        "Player %d:"
+#~ msgstr       "Joueur n°%d  :"
+
+#~ msgid        "%s:"
+#~ msgstr       "%s :"

--- a/android/assets/po/messages.pot
+++ b/android/assets/po/messages.pot
@@ -81,7 +81,7 @@ msgstr  ""
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  ""
 
@@ -206,31 +206,32 @@ msgid   "Translations"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  ""
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  ""
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:77
@@ -250,20 +251,19 @@ msgid   "Nickoriginal"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
+msgid   "Bengali:"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
+msgid   "Oymate"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
+msgid   "Chinese:"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
+msgid   "Lu Xu"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:89
@@ -566,7 +566,7 @@ msgstr  ""
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  ""
 
@@ -578,19 +578,19 @@ msgstr  ""
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  ""
 
@@ -610,7 +610,7 @@ msgstr  ""
 msgid   "Finish first at %s championship"
 msgstr  ""
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"

--- a/android/assets/po/pl.po
+++ b/android/assets/po/pl.po
@@ -1,15 +1,15 @@
 # PandaCoderPL <translator@pandacoderpl.anonaddy.me>, 2022.
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-05-15 10:30+0000\n"
-       "Last-Translator: PandaCoderPL <translator@pandacoderpl.anonaddy.me>\n"
-       "Language-Team: Polish\n"
-       "Language: pl_PL\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-05-15 10:30+0000\n"
+        "Last-Translator: PandaCoderPL <translator@pandacoderpl.anonaddy.me>\n"
+        "Language-Team: Polish\n"
+        "Language: pl_PL\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -78,7 +78,7 @@ msgstr  "Kod"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -203,32 +203,33 @@ msgid   "Translations"
 msgstr  "Tłumaczenia"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "Bengalski:"
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "Chiński:"
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "Francuski:"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  ""
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  ""
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "Hiszpański:"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "Francuski:"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -247,21 +248,20 @@ msgid   "Nickoriginal"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "Hiszpański:"
+msgid   "Bengali:"
+msgstr  "Bengalski:"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  ""
+msgid   "Chinese:"
+msgstr  "Chiński:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  ""
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -570,7 +570,7 @@ msgstr  ""
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "#"
 
@@ -582,19 +582,19 @@ msgstr  "Najlepsze okrążenie"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "Zawodnik"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "Łączny czas"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "Punkty"
 
@@ -617,7 +617,7 @@ msgstr  "Pozycja 3 lub lepsza na mistrzostwach %s"
 msgid   "Finish first at %s championship"
 msgstr  "Pozycja 3 lub lepsza na mistrzostwach %s"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"
@@ -836,23 +836,23 @@ msgid   "OPEN LOG FILE FOLDER"
 msgstr  "OTWÓRZ FOLDER Z LOGAMI"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Police"
-#~ msgstr  "Polski:"
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "Polski:"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Red"
-#~ msgstr  "Gotowy!"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "Gotowy!"
 
 #, fuzzy
-#~ msgid   "Down | Brake:"
-#~ msgstr  "Hamulec:"
+#~ msgid        "Down | Brake:"
+#~ msgstr       "Hamulec:"
 
 #, fuzzy
-#~ msgid   "Left | Steer left:"
-#~ msgstr  "Skręć w lewo:"
+#~ msgid        "Left | Steer left:"
+#~ msgstr       "Skręć w lewo:"
 
 #, fuzzy
-#~ msgid   "Right | Steer right:"
-#~ msgstr  "Skręć w prawo:"
+#~ msgid        "Right | Steer right:"
+#~ msgstr       "Skręć w prawo:"

--- a/android/assets/po/ru.po
+++ b/android/assets/po/ru.po
@@ -3,17 +3,17 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Nickoriginal, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-06-01 11:11+0200\n"
-       "Last-Translator: Nickoriginal\n"
-       "Language-Team: Russian\n"
-       "Language: ru\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-06-01 11:11+0200\n"
+        "Last-Translator: Nickoriginal\n"
+        "Language-Team: Russian\n"
+        "Language: ru\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
@@ -80,7 +80,7 @@ msgstr  "Код"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -205,32 +205,33 @@ msgid   "Translations"
 msgstr  "Переводы"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "Бенгальский:"
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "Китайский:"
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "Французский:"
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  "Немецкий:"
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  "Кристиан Шрёттер"
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "Испанский:"
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  "Баскский:"
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  "Josu Igoa"
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "Французский:"
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -249,21 +250,20 @@ msgid   "Nickoriginal"
 msgstr  "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "Испанский:"
+msgid   "Bengali:"
+msgstr  "Бенгальский:"
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  "Баскский:"
+msgid   "Chinese:"
+msgstr  "Китайский:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -568,7 +568,7 @@ msgstr  "Восхитительно!"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "N°"
 
@@ -580,19 +580,19 @@ msgstr  "Лучший круг"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "Гонщик"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "Общее время"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "Очки"
 
@@ -609,10 +609,10 @@ msgid   "Finish second or better at %s championship"
 msgstr  "Приди к финишу вторым или ещё быстрее на чемпионате %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
-msgid "Finish first at %s championship"
-msgstr "Приди к финишу первым на чемпионате %s"
+msgid   "Finish first at %s championship"
+msgstr  "Приди к финишу первым на чемпионате %s"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"

--- a/android/assets/po/zh_CN.po
+++ b/android/assets/po/zh_CN.po
@@ -3,17 +3,17 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Lu Xu <oliver_lew@outlook.com>, 2022.
 #
-msgid  ""
-msgstr "Project-Id-Version: \n"
-       "Report-Msgid-Bugs-To: \n"
-       "PO-Revision-Date: 2022-05-15 12:22+0800\n"
-       "Last-Translator: Lu Xu <oliver_lew@outlook.com>\n"
-       "Language-Team: Chinese\n"
-       "Language: zh_CN\n"
-       "MIME-Version: 1.0\n"
-       "Content-Type: text/plain; charset=UTF-8\n"
-       "Content-Transfer-Encoding: 8bit\n"
-       "Plural-Forms: nplurals=1; plural=0;\n"
+msgid   ""
+msgstr  "Project-Id-Version: \n"
+        "Report-Msgid-Bugs-To: \n"
+        "PO-Revision-Date: 2022-05-15 12:22+0800\n"
+        "Last-Translator: Lu Xu <oliver_lew@outlook.com>\n"
+        "Language-Team: Chinese\n"
+        "Language: zh_CN\n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Content-Transfer-Encoding: 8bit\n"
+        "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
@@ -82,7 +82,7 @@ msgstr  "代码"
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
-#: android/assets/screens/credits.gdxui:72
+#: android/assets/screens/credits.gdxui:75
 msgid   "Aurélien Gâteau"
 msgstr  "Aurélien Gâteau"
 
@@ -207,32 +207,33 @@ msgid   "Translations"
 msgstr  "翻译"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "Bengali:"
-msgstr  "孟加拉语："
-
-#: android/assets/screens/credits.gdxui:66
-msgid   "Oymate"
-msgstr  "Oymate"
-
-#: android/assets/screens/credits.gdxui:68
-msgid   "Chinese:"
-msgstr  "简体中文："
-
-#: android/assets/screens/credits.gdxui:69
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
-
-#: android/assets/screens/credits.gdxui:71
-msgid   "French:"
-msgstr  "法语："
-
-#: android/assets/screens/credits.gdxui:74
 msgid   "German:"
 msgstr  ""
 
-#: android/assets/screens/credits.gdxui:75
+#: android/assets/screens/credits.gdxui:66
 msgid   "Christian Schrötter"
 msgstr  ""
+
+#: android/assets/screens/credits.gdxui:68
+msgid   "Spanish:"
+msgstr  "西班牙语："
+
+#: android/assets/screens/credits.gdxui:69
+#: android/assets/screens/credits.gdxui:91
+msgid   "Clara Gâteau"
+msgstr  "Clara Gâteau"
+
+#: android/assets/screens/credits.gdxui:71
+msgid   "Basque:"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:72
+msgid   "Josu Igoa"
+msgstr  ""
+
+#: android/assets/screens/credits.gdxui:74
+msgid   "French:"
+msgstr  "法语："
 
 #: android/assets/screens/credits.gdxui:77
 msgid   "Polish:"
@@ -251,21 +252,20 @@ msgid   "Nickoriginal"
 msgstr  ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Spanish:"
-msgstr  "西班牙语："
+msgid   "Bengali:"
+msgstr  "孟加拉语："
 
 #: android/assets/screens/credits.gdxui:84
-#: android/assets/screens/credits.gdxui:91
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid   "Oymate"
+msgstr  "Oymate"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Basque:"
-msgstr  ""
+msgid   "Chinese:"
+msgstr  "简体中文："
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Josu Igoa"
-msgstr  ""
+msgid   "Lu Xu"
+msgstr  "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:89
 msgid   "Video Editing"
@@ -566,7 +566,7 @@ msgstr  "惊艳！"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "#"
 msgstr  "#"
 
@@ -578,19 +578,19 @@ msgstr  "最佳单圈"
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Racer"
 msgstr  "赛车手"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Total time"
 msgstr  "总用时"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:203
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
 msgid   "Points"
 msgstr  "分数"
 
@@ -613,7 +613,7 @@ msgstr  "在 %s 锦标赛取得至少第三名"
 msgid   "Finish first at %s championship"
 msgstr  "在 %s 锦标赛取得至少第三名"
 
-#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:185
+#: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
 msgid   "Championship\n"
         "Finished!"
@@ -828,29 +828,29 @@ msgid   "OPEN LOG FILE FOLDER"
 msgstr  "打开日志文件夹"
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Police"
-#~ msgstr  "波兰语："
+#~ msgctxt      "vehicle"
+#~ msgid        "Police"
+#~ msgstr       "波兰语："
 
 #, fuzzy
-#~ msgctxt "vehicle"
-#~ msgid   "Red"
-#~ msgstr  "准备！"
+#~ msgctxt      "vehicle"
+#~ msgid        "Red"
+#~ msgstr       "准备！"
 
 #, fuzzy
-#~ msgid   "Down | Brake:"
-#~ msgstr  "刹车："
+#~ msgid        "Down | Brake:"
+#~ msgstr       "刹车："
 
 #, fuzzy
-#~ msgid   "Left | Steer left:"
-#~ msgstr  "左转："
+#~ msgid        "Left | Steer left:"
+#~ msgstr       "左转："
 
 #, fuzzy
-#~ msgid   "Right | Steer right:"
-#~ msgstr  "右转："
+#~ msgid        "Right | Steer right:"
+#~ msgstr       "右转："
 
-#~ msgid   "OFF"
-#~ msgstr  "关"
+#~ msgid        "OFF"
+#~ msgstr       "关"
 
-#~ msgid   "ON"
-#~ msgstr  "开"
+#~ msgid        "ON"
+#~ msgstr       "开"

--- a/android/assets/screens/credits.gdxui
+++ b/android/assets/screens/credits.gdxui
@@ -62,17 +62,17 @@
                 <Label/>
                 <Label style="creditsSection">Translations</Label>
                 <Label/>
-                <Label>Bengali:</Label>
-                <Label>Oymate</Label>
+                <Label>German:</Label>
+                <Label>Christian Schrötter</Label>
                 <Label/>
-                <Label>Chinese:</Label>
-                <Label>Lu Xu</Label>
+                <Label>Spanish:</Label>
+                <Label>Clara Gâteau</Label>
+                <Label/>
+                <Label>Basque:</Label>
+                <Label>Josu Igoa</Label>
                 <Label/>
                 <Label>French:</Label>
                 <Label>Aurélien Gâteau</Label>
-                <Label/>
-                <Label>German:</Label>
-                <Label>Christian Schrötter</Label>
                 <Label/>
                 <Label>Polish:</Label>
                 <Label>PandaCoderPL</Label>
@@ -80,11 +80,11 @@
                 <Label>Russian:</Label>
                 <Label>Nickoriginal</Label>
                 <Label/>
-                <Label>Spanish:</Label>
-                <Label>Clara Gâteau</Label>
+                <Label>Bengali:</Label>
+                <Label>Oymate</Label>
                 <Label/>
-                <Label>Basque:</Label>
-                <Label>Josu Igoa</Label>
+                <Label>Chinese:</Label>
+                <Label>Lu Xu</Label>
                 <Label/>
                 <Label style="creditsSection">Video Editing</Label>
                 <Label/>

--- a/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
@@ -113,6 +113,7 @@ public class SelectLanguageScreen extends PwStageScreen {
     private GridMenuItem<Language> createLanguageSelector(Menu menu) {
         GridMenuItem<Language> languageSelector = new GridMenuItem<>(menu);
         Array<Language> languages = mGame.getAssets().languages.getAll();
+        languages.sort((l1, l2) -> l1.name.compareToIgnoreCase(l2.name));
         languageSelector.setItems(languages);
         languageSelector.setItemSize(menu.getWidth(), ITEM_HEIGHT);
         languageSelector.setColumnCount(1);


### PR DESCRIPTION
Automatically sort languages in LanguageScreen.
Sort them in credits.md following the order produced by LanguageScreen.
