### PR TITLE
Fix tracks being locked when restarting with gameplay-locking options

### DIFF
--- a/.changes/unreleased/Developers-20220922-115524.yaml
+++ b/.changes/unreleased/Developers-20220922-115524.yaml
@@ -1,0 +1,4 @@
+kind: Developers
+body: Enabling some gameplay-affecting debug settings no longer prevents using locked
+  tracks or vehicles.
+time: 2022-09-22T11:55:24.293378965+02:00

--- a/core/src/com/agateau/pixelwheels/PwGame.java
+++ b/core/src/com/agateau/pixelwheels/PwGame.java
@@ -70,7 +70,9 @@ public class PwGame extends Game implements GameConfig.ChangeListener {
     private final GameStatsImpl.IO mNoSaveGameStatsIO =
             new GameStatsImpl.IO() {
                 @Override
-                public void load(GameStatsImpl gameStats) {}
+                public void load(GameStatsImpl gameStats) {
+                    mNormalGameStatsIO.load(gameStats);
+                }
 
                 @Override
                 public void save(GameStatsImpl gameStats) {}


### PR DESCRIPTION
Loading stats is OK and required to be able to work on any track. We just
want to prevent saving stats.
