### PR TITLE
Gamepad config screen: fix "press key" text overflowing

### DIFF
--- a/.changes/unreleased/Fixed-20221010-200525.yaml
+++ b/.changes/unreleased/Fixed-20221010-200525.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Text no longer overflows its button in the gamepad configuration screen (#224).
+time: 2022-10-10T20:05:25.854414401+02:00

--- a/android/assets/po/bn.po
+++ b/android/assets/po/bn.po
@@ -3,896 +3,902 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Oymate, 2022.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-05-15 00:07+0200\n"
-        "Last-Translator: Oymate\n"
-        "Language-Team: Bengali\n"
-        "Language: bn\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=n > 1;\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-05-15 00:07+0200\n"
+"Last-Translator: Oymate\n"
+"Language-Team: Bengali\n"
+"Language: bn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "গ্রাম্য জীবন প্রতিযোগিতা"
+msgid "Country Life"
+msgstr "গ্রাম্য জীবন প্রতিযোগিতা"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  ""
+msgid "Welcome!"
+msgstr ""
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  ""
+msgid "River"
+msgstr ""
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  ""
+msgid "Flood"
+msgstr ""
 
 #: android/assets/championships/1.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "বর্গাকার পাহাড় প্রতিযোগিতা:"
+msgid "Square Mountains"
+msgstr "বর্গাকার পাহাড় প্রতিযোগিতা:"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  ""
+msgid "Let it snow"
+msgstr ""
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  ""
+msgid "Don't slip!"
+msgstr ""
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  ""
+msgid "Pix Cities"
+msgstr ""
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  ""
+msgid "Blocky Town"
+msgstr ""
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  ""
+msgid "Tiny sur Mer"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "পিক্সেল হুইল"
+msgid "Pixel Wheels"
+msgstr "পিক্সেল হুইল"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "একটি মুক্ত-উৎস গাড়ি দৌড় খেলা"
+msgid "An open-source racing game"
+msgstr "একটি মুক্ত-উৎস গাড়ি দৌড় খেলা"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "কোড"
+msgid "Code"
+msgstr "কোড"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "অরেলিয়েন গাটেউ"
+msgid "Aurélien Gâteau"
+msgstr "অরেলিয়েন গাটেউ"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "পিক্সেল"
+msgid "Pixels"
+msgstr "পিক্সেল"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "অ্যান্টনিও গাটেও"
+msgid "Antonin Gâteau"
+msgstr "অ্যান্টনিও গাটেও"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "সংগীত"
+msgid "Music"
+msgstr "সংগীত"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "তালিকা:"
+msgid "Menu:"
+msgstr "তালিকা:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"আলোর গতি\""
+msgid "\"Lightspeed\""
+msgstr "\"আলোর গতি\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "থোমাস ট্রিপন"
+msgid "Thomas Tripon"
+msgstr "থোমাস ট্রিপন"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "বিজয়:"
+msgid "Victory:"
+msgstr "বিজয়:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"মূল উত্তরাধিকার (১৬-বিট) সং০.৯\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"মূল উত্তরাধিকার (১৬-বিট) সং০.৯\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "ফক্সসিনার্জি"
+msgid "FoxSynergy"
+msgstr "ফক্সসিনার্জি"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "গ্রাম্য জীবন প্রতিযোগিতা"
+msgid "Country Life championship:"
+msgstr "গ্রাম্য জীবন প্রতিযোগিতা"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"মহাবিস্ফোরণ সং১.০\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"মহাবিস্ফোরণ সং১.০\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "বর্গাকার পাহাড় প্রতিযোগিতা:"
+msgid "Square Mountains championship:"
+msgstr "বর্গাকার পাহাড় প্রতিযোগিতা:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"চন্দ্র ফসল সং১.০\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"চন্দ্র ফসল সং১.০\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "পিক্স শহর প্রতিযোগিতা:"
+msgid "Pix Cities championship:"
+msgstr "পিক্স শহর প্রতিযোগিতা:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"লাফানো বল সং০.৯৫\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"লাফানো বল সং০.৯৫\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "শব্দ প্রভাব"
+msgid "Sound Effects"
+msgstr "শব্দ প্রভাব"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"গাড়ির চাকা পিছলিয়ে ঘূর্ণন\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"গাড়ির চাকা পিছলিয়ে ঘূর্ণন\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "টম হাইগ"
+msgid "Tom Haigh"
+msgstr "টম হাইগ"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"দৌড় গাড়ির ইঞ্জিনের শব্দ চক্রাকারে\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"দৌড় গাড়ির ইঞ্জিনের শব্দ চক্রাকারে\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "ডোমাসএক্স২"
+msgid "domasx2"
+msgstr "ডোমাসএক্স২"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "অন্যান্য শব্দ প্রভাব"
+msgid "Other sound effects"
+msgstr "অন্যান্য শব্দ প্রভাব"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "ফন্ট"
+msgid "Fonts"
+msgstr "ফন্ট"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "জোলোনিয়াম"
+msgid "Xolonium"
+msgstr "জোলোনিয়াম"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "সেভেরিন মেয়ের"
+msgid "Severin Meyer"
+msgstr "সেভেরিন মেয়ের"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "কাজং"
+msgid "Kwajong"
+msgstr "কাজং"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "টাপ ওয়ান্ডার"
+msgid "Tup Wanders"
+msgstr "টাপ ওয়ান্ডার"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  ""
+msgid "Noto"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  ""
+msgid "Google"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "অনুবাদ"
+msgid "Translations"
+msgstr "অনুবাদ"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  ""
+msgid "German:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  ""
+msgid "Christian Schrötter"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "স্পেনীয়:"
+msgid "Spanish:"
+msgstr "স্পেনীয়:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "ক্লারা গাটেই"
+msgid "Clara Gâteau"
+msgstr "ক্লারা গাটেই"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  ""
+msgid "Basque:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  ""
+msgid "Josu Igoa"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "ফরাসি:"
+msgid "French:"
+msgstr "ফরাসি:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "পোলিশ"
+msgid "Polish:"
+msgstr "পোলিশ"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "পান্ডাকোডারপিএল"
+msgid "PandaCoderPL"
+msgstr "পান্ডাকোডারপিএল"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "স্পেনীয়:"
+msgid "Swedish:"
+msgstr "স্পেনীয়:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  ""
+msgid "Russian:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  ""
+msgid "Nickoriginal"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  ""
+msgid "Bengali:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  ""
+msgid "Oymate"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  ""
+msgid "Chinese:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  ""
+msgid "Lu Xu"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "ভিডিও সম্পাদনা"
+msgid "Video Editing"
+msgstr "ভিডিও সম্পাদনা"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "বিশেষ ধন্যবাদ"
+msgid "Special Thanks"
+msgstr "বিশেষ ধন্যবাদ"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "গিলম রচে"
+msgid "Guillaume Roche"
+msgstr "গিলম রচে"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "এথান চ্যাপম্যান"
+msgid "Ethan Chapman"
+msgstr "এথান চ্যাপম্যান"
 
 #: android/assets/screens/credits.gdxui:101
 #, fuzzy
-msgid   "All bug reporters"
-msgstr  "এবং সব গিটহাব সমস্যা প্রতিবেদক"
+msgid "All bug reporters"
+msgstr "এবং সব গিটহাব সমস্যা প্রতিবেদক"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "প্যাট্রন, কো-ফি এবং পেপালের সব সাহায্যকারীরা"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "প্যাট্রন, কো-ফি এবং পেপালের সব সাহায্যকারীরা"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "তৈরির জন্য ব্যবহৃত"
+msgid "Made with"
+msgstr "তৈরির জন্য ব্যবহৃত"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "লিবজিডিএক্স"
+msgid "LibGDX"
+msgstr "লিবজিডিএক্স"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "টাইলড"
+msgid "Tiled"
+msgstr "টাইলড"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "অ্যাশপ্রিট"
+msgid "Aseprite"
+msgstr "অ্যাশপ্রিট"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "এসএফএক্সআর কিউটি"
+msgid "SFXR Qt"
+msgstr "এসএফএক্সআর কিউটি"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "অ্যান্ড্রয়েড স্টুডিও"
+msgid "Android Studio"
+msgstr "অ্যান্ড্রয়েড স্টুডিও"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "এই খেলা প্রভাবকারী পছন্দ পরিবর্তিত হয়েছে, খেলার সংখ্যা সংরক্ষণ হবে না"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr "এই খেলা প্রভাবকারী পছন্দ পরিবর্তিত হয়েছে, খেলার সংখ্যা সংরক্ষণ হবে না"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "পুনঃশুরু"
+msgid "RESTART"
+msgstr "পুনঃশুরু"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "তালিকসয় ফেরত যাও"
+msgid "BACK TO MENU"
+msgstr "তালিকসয় ফেরত যাও"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "এগিয়ে যাও"
+msgid "CONTINUE"
+msgstr "এগিয়ে যাও"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "গেমপ্যাড পছন্দসমূহ"
+msgid "Gamepad config"
+msgstr "গেমপ্যাড পছন্দসমূহ"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "ঘোড়া:"
+msgid "Trigger:"
+msgstr "ঘোড়া:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "পিছনে"
+msgid "Back/reverse:"
+msgstr "পিছনে"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "কিবোর্ড পছন্দসমূহ"
+msgid "Keyboard config"
+msgstr "কিবোর্ড পছন্দসমূহ"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "একক খেলোয়াড়"
+msgid "ONE PLAYER"
+msgstr "একক খেলোয়াড়"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "একাধিক খেলোয়াড়"
+msgid "MULTI PLAYER"
+msgstr "একাধিক খেলোয়াড়"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "দ্রুত গাড়ি দৌড়"
+msgid "QUICK RACE"
+msgstr "দ্রুত গাড়ি দৌড়"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "প্রতিযোগিতা"
+msgid "CHAMPIONSHIP"
+msgstr "প্রতিযোগিতা"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "পছন্দসমূহ"
+msgid "SETTINGS"
+msgstr "পছন্দসমূহ"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "প্রস্থান"
+msgid "QUIT"
+msgstr "প্রস্থান"
 
 #: android/assets/screens/multiplayer.gdxui:10
 #, fuzzy
-msgid   "Select Your Vehicles"
-msgstr  "বাহন নাও"
+msgid "Select Your Vehicles"
+msgstr "বাহন নাও"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "প্রস্তুত!"
+msgid "Ready!"
+msgstr "প্রস্তুত!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "কিছু গেমপ্যাড নেই"
+msgid "Some gamepads are missing"
+msgstr "কিছু গেমপ্যাড নেই"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "থামানো"
+msgid "Paused"
+msgstr "থামানো"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "চালু করো"
+msgid "RESUME"
+msgstr "চালু করো"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "তালিকায় প্রস্থান করো"
+msgid "QUIT TO MENU"
+msgstr "তালিকায় প্রস্থান করো"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "প্রতিযোগিতা নির্বাচন"
+msgid "Select Championship"
+msgstr "প্রতিযোগিতা নির্বাচন"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "খেলার অবস্থা নির্বাচন"
+msgid "Select Game Mode"
+msgstr "খেলার অবস্থা নির্বাচন"
 
 #: android/assets/screens/selectlanguage.gdxui:5
 #, fuzzy
-msgid   "Select Language"
-msgstr  "ভাষা"
+msgid "Select Language"
+msgstr "ভাষা"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "রাস্তা নির্বাচন"
+msgid "Select Track"
+msgstr "রাস্তা নির্বাচন"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "সর্বোত্তম দৌড়"
+msgid "Best Lap"
+msgstr "সর্বোত্তম দৌড়"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "সর্বোচ্চ মোট"
+msgid "Best Total"
+msgstr "সর্বোচ্চ মোট"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "বাহন নাও"
+msgid "Select Your Vehicle"
+msgstr "বাহন নাও"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  ""
+msgid "2-Deuch"
+msgstr ""
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  ""
+msgid "Ant On-1"
+msgstr ""
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  ""
+msgid "Dark M"
+msgstr ""
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  ""
+msgid "Harvester"
+msgstr ""
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  ""
+msgid "Jeep"
+msgstr ""
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  ""
+msgid "Miramar"
+msgstr ""
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  ""
+msgid "Pickup"
+msgstr ""
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  ""
+msgid "Highway Patrol"
+msgstr ""
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  ""
+msgid "Red Lightning"
+msgstr ""
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  ""
+msgid "Roadster"
+msgstr ""
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  ""
+msgid "Rocket"
+msgstr ""
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  ""
+msgid "Santa Truck"
+msgstr ""
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "ভাগের মাধ্যম"
+msgid "Share via"
+msgstr "ভাগের মাধ্যম"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "সমস্যা পেয়েছো? এই বোতাম দিয়ে প্রতিবেদন পাঠাও।"
+msgid "Hit a bug? Use this button to report it."
+msgstr "সমস্যা পেয়েছো? এই বোতাম দিয়ে প্রতিবেদন পাঠাও।"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "সমস্যা প্রতিবেদন পাঠাও"
+msgid "REPORT BUG"
+msgstr "সমস্যা প্রতিবেদন পাঠাও"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "একটি বাহনে মিসাইল ছোড়ো"
-msgstr[1]       "%#টি বাহনে মিসাইল ছোড়ো"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "একটি বাহনে মিসাইল ছোড়ো"
+msgstr[1] "%#টি বাহনে মিসাইল ছোড়ো"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "রাস্তা একবার ছাড়ো"
-msgstr[1]       "রাস্তা %# বার ছাড়ো"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "রাস্তা একবার ছাড়ো"
+msgstr[1] "রাস্তা %# বার ছাড়ো"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "একটি অতিরিক্ত নাও"
-msgstr[1]       "%#টি অতিরিক্ত নাও"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "একটি অতিরিক্ত নাও"
+msgstr[1] "%#টি অতিরিক্ত নাও"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "গেমপ্যাড"
+msgid "Gamepad"
+msgstr "গেমপ্যাড"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "কিবোর্ড"
+msgid "Keyboard"
+msgstr "কিবোর্ড"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "চাকা বোতাম"
+msgid "Pie buttons"
+msgstr "চাকা বোতাম"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "পাশের বোতাম"
+msgid "Side buttons"
+msgstr "পাশের বোতাম"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "ক্রম"
+msgid "Championship Rankings"
+msgstr "ক্রম"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "প্রতিযোগিতার ফল"
+msgid "Race Results"
+msgstr "প্রতিযোগিতার ফল"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
 #, fuzzy
-msgid   "Congratulations, great race!"
-msgstr  "অভিনন্দন!\n"
-        "তুমি একটি সীমা(রেকর্ড) ভেঙেছো!"
+msgid "Congratulations, great race!"
+msgstr ""
+"অভিনন্দন!\n"
+"তুমি একটি সীমা(রেকর্ড) ভেঙেছো!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  ""
+msgid "You've got some serious driving skills!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  ""
+msgid "You're a champ!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  ""
+msgid "Congrats for this performance!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  ""
+msgid "Impressive!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "#"
+msgid "#"
+msgstr "#"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "সর্বোত্তম দৌড়"
+msgid "Best lap"
+msgstr "সর্বোত্তম দৌড়"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "দৌড়বিদ"
+msgid "Racer"
+msgstr "দৌড়বিদ"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "মোট সময়"
+msgid "Total time"
+msgstr "মোট সময়"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "পয়েন্ট"
+msgid "Points"
+msgstr "পয়েন্ট"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "দৌড়ের সময়"
+msgid "Race time"
+msgstr "দৌড়ের সময়"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, fuzzy, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
+msgid "Finish third or better at %s championship"
+msgstr "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, fuzzy, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
+msgid "Finish second or better at %s championship"
+msgstr "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, fuzzy, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
+msgid "Finish first at %s championship"
+msgstr "কমপক্ষে ৩য় হও %s প্রতিযোগিতায়"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 #, fuzzy
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "প্রতিযোগিতা\n"
-        "সমাপ্ত!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"প্রতিযোগিতা\n"
+"সমাপ্ত!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "সম্পর্কে"
+msgid "About"
+msgstr "সম্পর্কে"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "পিকগসেল হুইল %s"
+msgid "Pixel Wheels %s"
+msgstr "পিকগসেল হুইল %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "কৃতজ্ঞতা"
+msgid "CREDITS"
+msgstr "কৃতজ্ঞতা"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "পিক্সেল হুইল খেলতে টাকা লাগে না,\n"
-        "কিন্তু এর বিকাশে বিভিন্নভাবে সাহায্য করতে পারো"
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"পিক্সেল হুইল খেলতে টাকা লাগে না,\n"
+"কিন্তু এর বিকাশে বিভিন্নভাবে সাহায্য করতে পারো"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "সহায়তা পৃষ্ঠা দেখো"
+msgid "VISIT SUPPORT PAGE"
+msgstr "সহায়তা পৃষ্ঠা দেখো"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "পিক্সেল হুইল নিয়ে আরো জানো"
+msgid "Learn more about Pixel Wheels"
+msgstr "পিক্সেল হুইল নিয়ে আরো জানো"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "ওয়েবসাইট দেখো"
+msgid "VISIT WEB SITE"
+msgstr "ওয়েবসাইট দেখো"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "ঢাকনার নিচে"
+msgid "Under the hood"
+msgstr "ঢাকনার নিচে"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "এই পছন্দসমূহ মূলত প্রকৌশলগত কারণে এখানে, কিন্তু এগুলো ব্যবহারে ভয় পেও না"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr "এই পছন্দসমূহ মূলত প্রকৌশলগত কারণে এখানে, কিন্তু এগুলো ব্যবহারে ভয় পেও না"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "প্রকৌশলী পছন্দসমূহ"
+msgid "DEV. OPTIONS"
+msgstr "প্রকৌশলী পছন্দসমূহ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "পছন্দসমূহ"
+msgid "Controls"
+msgstr "পছন্দসমূহ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "খেলোয়াড় #%d:"
+msgid "Player #%d:"
+msgstr "খেলোয়াড় #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "পছন্দসমূহ"
+msgid "Controls:"
+msgstr "পছন্দসমূহ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "সাধারণ"
+msgid "General"
+msgstr "সাধারণ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "ভাষা"
+msgid "Language:"
+msgstr "ভাষা"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "শব্দ"
+msgid "Audio"
+msgstr "শব্দ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "সংগীত প্রভাব:"
+msgid "Sound FX:"
+msgstr "সংগীত প্রভাব:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "সংগীত"
+msgid "Music:"
+msgstr "সংগীত"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "ভিডিও"
+msgid "Video"
+msgstr "ভিডিও"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "বড়পর্দা"
+msgid "Fullscreen:"
+msgstr "বড়পর্দা"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "পাল্টাও"
+msgid "CONFIGURE"
+msgstr "পাল্টাও"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "খেলার জন্য ধন্যবাদ!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  ""
+msgid "Thank you for playing!"
+msgstr "খেলার জন্য ধন্যবাদ!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
 #, fuzzy
-msgid   "Brake"
-msgstr  "ব্রেক:"
+msgid "Brake"
+msgstr "ব্রেক:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
 #, fuzzy
-msgid   "Steer left"
-msgstr  "বামে যাও:"
+msgid "Steer left"
+msgstr "বামে যাও:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
 #, fuzzy
-msgid   "Steer right"
-msgstr  "ডানে যাও:"
+msgid "Steer right"
+msgstr "ডানে যাও:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
 #, fuzzy
-msgid   "Trigger"
-msgstr  "ঘোড়া:"
+msgid "Trigger"
+msgstr "ঘোড়া:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  ""
+msgid "Up"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  ""
+msgid "Down"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  ""
+msgid "Left"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  ""
+msgid "Right"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  ""
+msgid "Activate"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  ""
+msgid "Back"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "নেই/ হারিয়ে গেছে"
+msgid "Missing"
+msgstr "নেই/ হারিয়ে গেছে"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "আচ্ছা"
+msgid "OK"
+msgstr "আচ্ছা"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "খেলোয়াড় #%d: %s"
+msgid "Player #%d: %s"
+msgstr "খেলোয়াড় #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "মূল পৃষ্ঠা"
+msgid "MAIN MENU"
+msgstr "মূল পৃষ্ঠা"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[তালাবদ্ধ]"
+msgid "[Locked]"
+msgstr "[তালাবদ্ধ]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  ""
+msgid "CPU"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  ""
+msgid "New vehicle unlocked!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
 #, fuzzy
-msgid   "New championship unlocked!"
-msgstr  "প্রতিযোগিতা\n"
-        "সমাপ্ত!"
+msgid "New championship unlocked!"
+msgstr ""
+"প্রতিযোগিতা\n"
+"সমাপ্ত!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "১ম"
+msgid "1st"
+msgstr "১ম"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "২য়"
+msgid "2nd"
+msgstr "২য়"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "৩য়"
+msgid "3rd"
+msgstr "৩য়"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "৪র্থ"
+msgid "4th"
+msgstr "৪র্থ"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "৫ম"
+msgid "5th"
+msgstr "৫ম"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "৬ষ্ঠ"
+msgid "6th"
+msgstr "৬ষ্ঠ"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "সমস্যা প্রতিবেদন করতে চাও? এই বোতাম দিয়ে সংযুক্ত সূচীর নথিটি পাবে"
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr "সমস্যা প্রতিবেদন করতে চাও? এই বোতাম দিয়ে সংযুক্ত সূচীর নথিটি পাবে"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "লগ বা সূচী ফাইলের ফোল্ডার খুঁজে বের করো"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "লগ বা সূচী ফাইলের ফোল্ডার খুঁজে বের করো"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "পোলিশ"
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "পোলিশ"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "প্রস্তুত!"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "প্রস্তুত!"
 
 #, fuzzy
-#~ msgid        "Down | Brake:"
-#~ msgstr       "ব্রেক:"
+#~ msgid "Down | Brake:"
+#~ msgstr "ব্রেক:"
 
 #, fuzzy
-#~ msgid        "Left | Steer left:"
-#~ msgstr       "বামে যাও:"
+#~ msgid "Left | Steer left:"
+#~ msgstr "বামে যাও:"
 
 #, fuzzy
-#~ msgid        "Right | Steer right:"
-#~ msgstr       "ডানে যাও:"
+#~ msgid "Right | Steer right:"
+#~ msgstr "ডানে যাও:"
 
-#~ msgid        "Finished!"
-#~ msgstr       "সম্পন্ন!"
+#~ msgid "Finished!"
+#~ msgstr "সম্পন্ন!"
 
-#~ msgid        "Beta Testers"
-#~ msgstr       "পরীক্ষামূলক ব্যবহারকারী"
+#~ msgid "Beta Testers"
+#~ msgstr "পরীক্ষামূলক ব্যবহারকারী"
 
-#~ msgid        "(thank you!)"
-#~ msgstr       "(ধন্যবাদ!)"
+#~ msgid "(thank you!)"
+#~ msgstr "(ধন্যবাদ!)"
 
-#~ msgid        "OFF"
-#~ msgstr       "বন্ধ"
+#~ msgid "OFF"
+#~ msgstr "বন্ধ"
 
-#~ msgid        "ON"
-#~ msgstr       "চালু"
+#~ msgid "ON"
+#~ msgstr "চালু"

--- a/android/assets/po/de.po
+++ b/android/assets/po/de.po
@@ -1,844 +1,858 @@
 # Christian Schrötter <cs@fnx.li>, 2022.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-07-03 17:56+0200\n"
-        "Last-Translator: Christian Schrötter <cs@fnx.li>\n"
-        "Language-Team: German\n"
-        "Language: de_DE\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-07-03 17:56+0200\n"
+"Last-Translator: Christian Schrötter <cs@fnx.li>\n"
+"Language-Team: German\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Provinz"
+msgid "Country Life"
+msgstr "Provinz"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "Willkommen!"
+msgid "Welcome!"
+msgstr "Willkommen!"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Flussrundfahrt"
+msgid "River"
+msgstr "Flussrundfahrt"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Land unter!"
+msgid "Flood"
+msgstr "Land unter!"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Gebirgsrallye"
+msgid "Square Mountains"
+msgstr "Gebirgsrallye"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Schneelandschaft"
+msgid "Let it snow"
+msgstr "Schneelandschaft"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "Blitzeis!"
+msgid "Don't slip!"
+msgstr "Blitzeis!"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "Pixelstädte"
+msgid "Pix Cities"
+msgstr "Pixelstädte"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Blockstadt"
+msgid "Blocky Town"
+msgstr "Blockstadt"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Pix am See"
+msgid "Tiny sur Mer"
+msgstr "Pix am See"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Ein Open-Source-Rennspiel"
+msgid "An open-source racing game"
+msgstr "Ein Open-Source-Rennspiel"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Programmierung"
+msgid "Code"
+msgstr "Programmierung"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Grafik"
+msgid "Pixels"
+msgstr "Grafik"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Musik"
+msgid "Music"
+msgstr "Musik"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Menü:"
+msgid "Menu:"
+msgstr "Menü:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Erfolg:"
+msgid "Victory:"
+msgstr "Erfolg:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Provinz Meisterschaft:"
+msgid "Country Life championship:"
+msgstr "Provinz Meisterschaft:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Gebirgsrallye Meisterschaft:"
+msgid "Square Mountains championship:"
+msgstr "Gebirgsrallye Meisterschaft:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Pixelstädte Meisterschaft:"
+msgid "Pix Cities championship:"
+msgstr "Pixelstädte Meisterschaft:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Soundeffekte"
+msgid "Sound Effects"
+msgstr "Soundeffekte"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Andere Soundeffekte"
+msgid "Other sound effects"
+msgstr "Andere Soundeffekte"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Schriftarten"
+msgid "Fonts"
+msgstr "Schriftarten"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Übersetzungen"
+msgid "Translations"
+msgstr "Übersetzungen"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Deutsch:"
+msgid "German:"
+msgstr "Deutsch:"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Christian Schrötter"
+msgid "Christian Schrötter"
+msgstr "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Spanisch:"
+msgid "Spanish:"
+msgstr "Spanisch:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Baskisch:"
+msgid "Basque:"
+msgstr "Baskisch:"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Französisch:"
+msgid "French:"
+msgstr "Französisch:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Polnisch:"
+msgid "Polish:"
+msgstr "Polnisch:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "Spanisch:"
+msgid "Swedish:"
+msgstr "Spanisch:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Russisch:"
+msgid "Russian:"
+msgstr "Russisch:"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengalisch:"
+msgid "Bengali:"
+msgstr "Bengalisch:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Chinesisch:"
+msgid "Chinese:"
+msgstr "Chinesisch:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Videobearbeitung"
+msgid "Video Editing"
+msgstr "Videobearbeitung"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Besonderer Dank an"
+msgid "Special Thanks"
+msgstr "Besonderer Dank an"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Alle Leute, die Fehler gemeldet haben."
+msgid "All bug reporters"
+msgstr "Alle Leute, die Fehler gemeldet haben."
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Alle Unterstützer auf Patreon, Ko-fi und PayPal."
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Alle Unterstützer auf Patreon, Ko-fi und PayPal."
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Realisiert mit"
+msgid "Made with"
+msgstr "Realisiert mit"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Es wurden Einstellungen geändert, die den Spielablauf betreffen.\n"
-        "Die erzielten Ergebnisse und Rekorde werden nicht gespeichert!"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Es wurden Einstellungen geändert, die den Spielablauf betreffen.\n"
+"Die erzielten Ergebnisse und Rekorde werden nicht gespeichert!"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "NEUSTART"
+msgid "RESTART"
+msgstr "NEUSTART"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "HAUPTMENÜ"
+msgid "BACK TO MENU"
+msgstr "HAUPTMENÜ"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "FORTFAHREN"
+msgid "CONTINUE"
+msgstr "FORTFAHREN"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Gamepad Konfiguration"
+msgid "Gamepad config"
+msgstr "Gamepad Konfiguration"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Auslöser"
+msgid "Trigger:"
+msgstr "Auslöser"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Zurückfahren"
+msgid "Back/reverse:"
+msgstr "Zurückfahren"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Tastatur Konfiguration"
+msgid "Keyboard config"
+msgstr "Tastatur Konfiguration"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "EINZELSPIELER"
+msgid "ONE PLAYER"
+msgstr "EINZELSPIELER"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "MEHRSPIELER"
+msgid "MULTI PLAYER"
+msgstr "MEHRSPIELER"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "SCHNELLES RENNEN"
+msgid "QUICK RACE"
+msgstr "SCHNELLES RENNEN"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "MEISTERSCHAFT"
+msgid "CHAMPIONSHIP"
+msgstr "MEISTERSCHAFT"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "EINSTELLUNGEN"
+msgid "SETTINGS"
+msgstr "EINSTELLUNGEN"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "BEENDEN"
+msgid "QUIT"
+msgstr "BEENDEN"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid   "Select Your Vehicles"
-msgstr  "Wähle dein Fahrzeug"
+msgid "Select Your Vehicles"
+msgstr "Wähle dein Fahrzeug"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Fertig!"
+msgid "Ready!"
+msgstr "Fertig!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Einige Gamepads fehlen"
+msgid "Some gamepads are missing"
+msgstr "Einige Gamepads fehlen"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Pausiert"
+msgid "Paused"
+msgstr "Pausiert"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "FORTSETZEN"
+msgid "RESUME"
+msgstr "FORTSETZEN"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "BEENDEN UND ZUM MENÜ"
+msgid "QUIT TO MENU"
+msgstr "BEENDEN UND ZUM MENÜ"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Meisterschaft auswählen"
+msgid "Select Championship"
+msgstr "Meisterschaft auswählen"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Spielmodus auswählen"
+msgid "Select Game Mode"
+msgstr "Spielmodus auswählen"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid   "Select Language"
-msgstr  "Sprache auswählen"
+msgid "Select Language"
+msgstr "Sprache auswählen"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Strecke auswählen"
+msgid "Select Track"
+msgstr "Strecke auswählen"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Beste Rundenzeit"
+msgid "Best Lap"
+msgstr "Beste Rundenzeit"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Beste Gesamtzeit"
+msgid "Best Total"
+msgstr "Beste Gesamtzeit"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Wähle dein Fahrzeug"
+msgid "Select Your Vehicle"
+msgstr "Wähle dein Fahrzeug"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "Ente"
+msgid "2-Deuch"
+msgstr "Ente"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ant On-1"
+msgid "Ant On-1"
+msgstr "Ant On-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "Dark M"
+msgid "Dark M"
+msgstr "Dark M"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Mähdrescher"
+msgid "Harvester"
+msgstr "Mähdrescher"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Jeep"
+msgid "Jeep"
+msgstr "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Miramar"
+msgid "Miramar"
+msgstr "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Pick-up"
+msgid "Pickup"
+msgstr "Pick-up"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Polizei"
+msgid "Highway Patrol"
+msgstr "Polizei"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Rennwagen"
+msgid "Red Lightning"
+msgstr "Rennwagen"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Roadster"
+msgid "Roadster"
+msgstr "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Rakete"
+msgid "Rocket"
+msgstr "Rakete"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Santa Truck"
+msgid "Santa Truck"
+msgstr "Santa Truck"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Teilen über"
+msgid "Share via"
+msgstr "Teilen über"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Fehler gefunden? Hier kannst du ihn melden!"
+msgid "Hit a bug? Use this button to report it."
+msgstr "Fehler gefunden? Hier kannst du ihn melden!"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "FEHLER MELDEN"
+msgid "REPORT BUG"
+msgstr "FEHLER MELDEN"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Treffe ein Fahrzeug mit einer Rakete"
-msgstr[1]       "Treffe %# Fahrzeuge mit einer Rakete"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Treffe ein Fahrzeug mit einer Rakete"
+msgstr[1] "Treffe %# Fahrzeuge mit einer Rakete"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Verlasse einmal die Straße"
-msgstr[1]       "Verlasse %# mal die Straße"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Verlasse einmal die Straße"
+msgstr[1] "Verlasse %# mal die Straße"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Wähle einen Bonus aus"
-msgstr[1]       "Wähle %# Boni aus"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Wähle einen Bonus aus"
+msgstr[1] "Wähle %# Boni aus"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Gamepad"
+msgid "Gamepad"
+msgstr "Gamepad"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Tastatur"
+msgid "Keyboard"
+msgstr "Tastatur"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Ecktasten"
+msgid "Pie buttons"
+msgstr "Ecktasten"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Seitliche Tasten"
+msgid "Side buttons"
+msgstr "Seitliche Tasten"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Ergebnis der Meisterschaft"
+msgid "Championship Rankings"
+msgstr "Ergebnis der Meisterschaft"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Ergebnis des Rennens"
+msgid "Race Results"
+msgstr "Ergebnis des Rennens"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "Gratulation, das war ein tolles Rennen!"
+msgid "Congratulations, great race!"
+msgstr "Gratulation, das war ein tolles Rennen!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "Du hast einige ernstzunehmende Fahrfähigkeiten!"
+msgid "You've got some serious driving skills!"
+msgstr "Du hast einige ernstzunehmende Fahrfähigkeiten!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "Du bist ein Champion!"
+msgid "You're a champ!"
+msgstr "Du bist ein Champion!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "Glückwunsch zu dieser fantastischen Leistung!"
+msgid "Congrats for this performance!"
+msgstr "Glückwunsch zu dieser fantastischen Leistung!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "Beeindruckend!"
+msgid "Impressive!"
+msgstr "Beeindruckend!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "#"
+msgid "#"
+msgstr "#"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Schnellste Runde"
+msgid "Best lap"
+msgstr "Schnellste Runde"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Rennfahrer"
+msgid "Racer"
+msgstr "Rennfahrer"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Gesamtzeit"
+msgid "Total time"
+msgstr "Gesamtzeit"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Punkte"
+msgid "Points"
+msgstr "Punkte"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Rennzeit"
+msgid "Race time"
+msgstr "Rennzeit"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Rang 3 oder besser bei der %s Meisterschaft"
+msgid "Finish third or better at %s championship"
+msgstr "Rang 3 oder besser bei der %s Meisterschaft"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Rang 3 oder besser bei der %s Meisterschaft"
+msgid "Finish second or better at %s championship"
+msgstr "Rang 3 oder besser bei der %s Meisterschaft"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Rang 3 oder besser bei der %s Meisterschaft"
+msgid "Finish first at %s championship"
+msgstr "Rang 3 oder besser bei der %s Meisterschaft"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "Meisterschaft\n"
-        "geschafft!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"Meisterschaft\n"
+"geschafft!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "Informationen"
+msgid "About"
+msgstr "Informationen"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "DANKSAGUNG"
+msgid "CREDITS"
+msgstr "DANKSAGUNG"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels ist freie Software, du kannst die weitere Entwicklung aber auf verschiedene Arten unterstützen."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels ist freie Software, du kannst die weitere Entwicklung aber auf "
+"verschiedene Arten unterstützen."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "UNTERSTÜTZEN"
+msgid "VISIT SUPPORT PAGE"
+msgstr "UNTERSTÜTZEN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Mehr über Pixel Wheels erfahren"
+msgid "Learn more about Pixel Wheels"
+msgstr "Mehr über Pixel Wheels erfahren"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "WEBSITE"
+msgid "VISIT WEB SITE"
+msgstr "WEBSITE"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Fehlersuche"
+msgid "Under the hood"
+msgstr "Fehlersuche"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Die folgenden Einstellungen sind hauptsächlich für die Entwicklung von Pixel Wheels relevant! Du kannst aber natürlich trotzdem herumstöbern und sie ausprobieren."
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Die folgenden Einstellungen sind hauptsächlich für die Entwicklung von Pixel "
+"Wheels relevant! Du kannst aber natürlich trotzdem herumstöbern und sie "
+"ausprobieren."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "ENTWICKLEROPTIONEN"
+msgid "DEV. OPTIONS"
+msgstr "ENTWICKLEROPTIONEN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Steuerung"
+msgid "Controls"
+msgstr "Steuerung"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Spieler #%d:"
+msgid "Player #%d:"
+msgstr "Spieler #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Steuerung:"
+msgid "Controls:"
+msgstr "Steuerung:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Allgemeines"
+msgid "General"
+msgstr "Allgemeines"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Sprache:"
+msgid "Language:"
+msgstr "Sprache:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Töne"
+msgid "Audio"
+msgstr "Töne"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Effekte:"
+msgid "Sound FX:"
+msgstr "Effekte:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Musik:"
+msgid "Music:"
+msgstr "Musik:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Anzeige"
+msgid "Video"
+msgstr "Anzeige"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Vollbildmodus:"
+msgid "Fullscreen:"
+msgstr "Vollbildmodus:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "KONFIGURIEREN"
+msgid "CONFIGURE"
+msgstr "KONFIGURIEREN"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Danke fürs Spielen!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Drücke die Taste am Gamepad..."
+msgid "Thank you for playing!"
+msgstr "Danke fürs Spielen!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Bremsen"
+msgid "Brake"
+msgstr "Bremsen"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Links lenken"
+msgid "Steer left"
+msgstr "Links lenken"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Rechts lenken"
+msgid "Steer right"
+msgstr "Rechts lenken"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Auslöser"
+msgid "Trigger"
+msgstr "Auslöser"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Rauf"
+msgid "Up"
+msgstr "Rauf"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Runter"
+msgid "Down"
+msgstr "Runter"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Links"
+msgid "Left"
+msgstr "Links"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Rechts"
+msgid "Right"
+msgstr "Rechts"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Auslösen"
+msgid "Activate"
+msgstr "Auslösen"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Zurück"
+msgid "Back"
+msgstr "Zurück"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Fehlt"
+msgid "Missing"
+msgstr "Fehlt"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "OK"
+msgid "OK"
+msgstr "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Spieler #%d: %s"
+msgid "Player #%d: %s"
+msgstr "Spieler #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "HAUPTMENÜ"
+msgid "MAIN MENU"
+msgstr "HAUPTMENÜ"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Gesperrt]"
+msgid "[Locked]"
+msgstr "[Gesperrt]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "Computer"
+msgid "CPU"
+msgstr "Computer"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "Neues Fahrzeug freigeschaltet!"
+msgid "New vehicle unlocked!"
+msgstr "Neues Fahrzeug freigeschaltet!"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "Neue Meisterschaft freigeschaltet!"
+msgid "New championship unlocked!"
+msgstr "Neue Meisterschaft freigeschaltet!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1."
+msgid "1st"
+msgstr "1."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2."
+msgid "2nd"
+msgstr "2."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3."
+msgid "3rd"
+msgstr "3."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4."
+msgid "4th"
+msgstr "4."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5."
+msgid "5th"
+msgstr "5."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6."
+msgid "6th"
+msgstr "6."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Willst du einen Fehler melden? Verwende die nachfolgende Schaltfläche, um den Ordner der Protokolldatei zu öffnen."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Willst du einen Fehler melden? Verwende die nachfolgende Schaltfläche, um "
+"den Ordner der Protokolldatei zu öffnen."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "PROTOKOLLORDNER"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "PROTOKOLLORDNER"
+
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Drücke die Taste am Gamepad..."

--- a/android/assets/po/es.po
+++ b/android/assets/po/es.po
@@ -4,876 +4,891 @@
 # Clara Gâteau, 2022.
 # Jorge Maldonado Ventura, 2022.
 # victorhck <victorhck@mailbox.org>, 2022.
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: \n"
-        "PO-Revision-Date: 2022-09-11 17:06+0200\n"
-        "Last-Translator: victorhck <victorhck@mailbox.org>\n"
-        "Language-Team: Spanish <>\n"
-        "Language: es\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-        "X-Generator: Lokalize 22.08.0\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2022-09-11 17:06+0200\n"
+"Last-Translator: victorhck <victorhck@mailbox.org>\n"
+"Language-Team: Spanish <>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 22.08.0\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Vida en el campo"
+msgid "Country Life"
+msgstr "Vida en el campo"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "¡Bienvenido!"
+msgid "Welcome!"
+msgstr "¡Bienvenido!"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Río"
+msgid "River"
+msgstr "Río"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Inundación"
+msgid "Flood"
+msgstr "Inundación"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Montes Cuadrados"
+msgid "Square Mountains"
+msgstr "Montes Cuadrados"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Nieva"
+msgid "Let it snow"
+msgstr "Nieva"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "¡No te resbales!"
+msgid "Don't slip!"
+msgstr "¡No te resbales!"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "Las ciudades de píxel"
+msgid "Pix Cities"
+msgstr "Las ciudades de píxel"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Ciudad de bloque"
+msgid "Blocky Town"
+msgstr "Ciudad de bloque"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Tiny en mar"
+msgid "Tiny sur Mer"
+msgstr "Tiny en mar"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Un juego de carreras de código abierto"
+msgid "An open-source racing game"
+msgstr "Un juego de carreras de código abierto"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Código"
+msgid "Code"
+msgstr "Código"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Píxeles"
+msgid "Pixels"
+msgstr "Píxeles"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Música"
+msgid "Music"
+msgstr "Música"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Menú:"
+msgid "Menu:"
+msgstr "Menú:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Victoria:"
+msgid "Victory:"
+msgstr "Victoria:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Campeonato Vida en el Campo:"
+msgid "Country Life championship:"
+msgstr "Campeonato Vida en el Campo:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Campeonato Montes Cuadrados:"
+msgid "Square Mountains championship:"
+msgstr "Campeonato Montes Cuadrados:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Campeonato Las ciudades de píxel:"
+msgid "Pix Cities championship:"
+msgstr "Campeonato Las ciudades de píxel:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Efectos sonoros"
+msgid "Sound Effects"
+msgstr "Efectos sonoros"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Otros efectos sonoros"
+msgid "Other sound effects"
+msgstr "Otros efectos sonoros"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Fuentes"
+msgid "Fonts"
+msgstr "Fuentes"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Traducciones"
+msgid "Translations"
+msgstr "Traducciones"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Alemán:"
+msgid "German:"
+msgstr "Alemán:"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Christian Schrötter"
+msgid "Christian Schrötter"
+msgstr "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Español:"
+msgid "Spanish:"
+msgstr "Español:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Euskera:"
+msgid "Basque:"
+msgstr "Euskera:"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Francés:"
+msgid "French:"
+msgstr "Francés:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Polaco:"
+msgid "Polish:"
+msgstr "Polaco:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
-msgid   "Swedish:"
-msgstr  "Sueco:"
+msgid "Swedish:"
+msgstr "Sueco:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  "Sanchez"
+msgid "Sanchez"
+msgstr "Sanchez"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Ruso:"
+msgid "Russian:"
+msgstr "Ruso:"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengalí:"
+msgid "Bengali:"
+msgstr "Bengalí:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Chino:"
+msgid "Chinese:"
+msgstr "Chino:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Edición de vídeo"
+msgid "Video Editing"
+msgstr "Edición de vídeo"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Un agradecimiento especial a"
+msgid "Special Thanks"
+msgstr "Un agradecimiento especial a"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Los informadores de errores"
+msgid "All bug reporters"
+msgstr "Los informadores de errores"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Todos los seguidores en Patreon, Ko-fi y Paypal"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Todos los seguidores en Patreon, Ko-fi y Paypal"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Creado con"
+msgid "Made with"
+msgstr "Creado con"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Se han modificado la configuración que afecta al juego, las puntuaciones no se guardarán"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Se han modificado la configuración que afecta al juego, las puntuaciones no "
+"se guardarán"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "RECOMENZAR"
+msgid "RESTART"
+msgstr "RECOMENZAR"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "VOLVER AL MENÚ"
+msgid "BACK TO MENU"
+msgstr "VOLVER AL MENÚ"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "CONTINUAR"
+msgid "CONTINUE"
+msgstr "CONTINUAR"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Configuración del mando"
+msgid "Gamepad config"
+msgstr "Configuración del mando"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Activar:"
+msgid "Trigger:"
+msgstr "Activar:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Atrás/volver atrás:"
+msgid "Back/reverse:"
+msgstr "Atrás/volver atrás:"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Configuración del teclado"
+msgid "Keyboard config"
+msgstr "Configuración del teclado"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "UN JUGADOR"
+msgid "ONE PLAYER"
+msgstr "UN JUGADOR"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "MULTIJUGADOR"
+msgid "MULTI PLAYER"
+msgstr "MULTIJUGADOR"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "CARRERA RÁPIDA"
+msgid "QUICK RACE"
+msgstr "CARRERA RÁPIDA"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "CAMPEONATO"
+msgid "CHAMPIONSHIP"
+msgstr "CAMPEONATO"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "CONFIGURACIÓN"
+msgid "SETTINGS"
+msgstr "CONFIGURACIÓN"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "SALIR"
+msgid "QUIT"
+msgstr "SALIR"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid   "Select Your Vehicles"
-msgstr  "Selecciona tus vehículos"
+msgid "Select Your Vehicles"
+msgstr "Selecciona tus vehículos"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "¡Listo!\t"
+msgid "Ready!"
+msgstr "¡Listo!\t"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Faltan algunos mandos"
+msgid "Some gamepads are missing"
+msgstr "Faltan algunos mandos"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Pausa"
+msgid "Paused"
+msgstr "Pausa"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "CONTINUAR"
+msgid "RESUME"
+msgstr "CONTINUAR"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "SALIR AL MENÚ"
+msgid "QUIT TO MENU"
+msgstr "SALIR AL MENÚ"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Seleccionar campeonato"
+msgid "Select Championship"
+msgstr "Seleccionar campeonato"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Seleccionar modo de juego"
+msgid "Select Game Mode"
+msgstr "Seleccionar modo de juego"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid   "Select Language"
-msgstr  "Seleccionar idioma"
+msgid "Select Language"
+msgstr "Seleccionar idioma"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Seleccionar circuito"
+msgid "Select Track"
+msgstr "Seleccionar circuito"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Mejor vuelta"
+msgid "Best Lap"
+msgstr "Mejor vuelta"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Mejor tiempo total"
+msgid "Best Total"
+msgstr "Mejor tiempo total"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Selecciona tu vehículo"
+msgid "Select Your Vehicle"
+msgstr "Selecciona tu vehículo"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "Dos Caballos"
+msgid "2-Deuch"
+msgstr "Dos Caballos"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ant On-1"
+msgid "Ant On-1"
+msgstr "Ant On-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "Dark M"
+msgid "Dark M"
+msgstr "Dark M"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Cosechadora"
+msgid "Harvester"
+msgstr "Cosechadora"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Jeep"
+msgid "Jeep"
+msgstr "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Miramar"
+msgid "Miramar"
+msgstr "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Pickup"
+msgid "Pickup"
+msgstr "Pickup"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Policía"
+msgid "Highway Patrol"
+msgstr "Policía"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Rayo Rojo"
+msgid "Red Lightning"
+msgstr "Rayo Rojo"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Roadster"
+msgid "Roadster"
+msgstr "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Cohete"
+msgid "Rocket"
+msgstr "Cohete"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Camión de Santa"
+msgid "Santa Truck"
+msgstr "Camión de Santa"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Compartir con"
+msgid "Share via"
+msgstr "Compartir con"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "¿Has encontrado un error? Utiliza este botón para notificarlo."
+msgid "Hit a bug? Use this button to report it."
+msgstr "¿Has encontrado un error? Utiliza este botón para notificarlo."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "NOTIFICAR DE UN ERROR"
+msgid "REPORT BUG"
+msgstr "NOTIFICAR DE UN ERROR"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Golpea un vehículo con un misil"
-msgstr[1]       "Golpea %# vehículos con un misil"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Golpea un vehículo con un misil"
+msgstr[1] "Golpea %# vehículos con un misil"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Sal de la carretera una vez"
-msgstr[1]       "Sal de la carretera %# veces"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Sal de la carretera una vez"
+msgstr[1] "Sal de la carretera %# veces"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Coge una bonificación"
-msgstr[1]       "Coge %# bonificaciones"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Coge una bonificación"
+msgstr[1] "Coge %# bonificaciones"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Mando"
+msgid "Gamepad"
+msgstr "Mando"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Teclado"
+msgid "Keyboard"
+msgstr "Teclado"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Botones en arco"
+msgid "Pie buttons"
+msgstr "Botones en arco"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Botones en el lado"
+msgid "Side buttons"
+msgstr "Botones en el lado"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Clasificación del campeonato"
+msgid "Championship Rankings"
+msgstr "Clasificación del campeonato"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Resultado de la carrera"
+msgid "Race Results"
+msgstr "Resultado de la carrera"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "¡Felicitaciones, magnífica carrera!"
+msgid "Congratulations, great race!"
+msgstr "¡Felicitaciones, magnífica carrera!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "¡Eres un piloto increíble!"
+msgid "You've got some serious driving skills!"
+msgstr "¡Eres un piloto increíble!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "¡Eres un campeón!"
+msgid "You're a champ!"
+msgstr "¡Eres un campeón!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "¡Bravo por esta actuación!"
+msgid "Congrats for this performance!"
+msgstr "¡Bravo por esta actuación!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "¡Impresionante!"
+msgid "Impressive!"
+msgstr "¡Impresionante!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "N°"
+msgid "#"
+msgstr "N°"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Mejor vuelta"
+msgid "Best lap"
+msgstr "Mejor vuelta"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Piloto"
+msgid "Racer"
+msgstr "Piloto"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Tiempo total"
+msgid "Total time"
+msgstr "Tiempo total"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Puntos"
+msgid "Points"
+msgstr "Puntos"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Tiempo de carrera"
+msgid "Race time"
+msgstr "Tiempo de carrera"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Queda tercero o mejor en el campeonato %s"
+msgid "Finish third or better at %s championship"
+msgstr "Queda tercero o mejor en el campeonato %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Queda segundo o mejor en el campeonato %s"
+msgid "Finish second or better at %s championship"
+msgstr "Queda segundo o mejor en el campeonato %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Queda primero en el campeonato %s"
+msgid "Finish first at %s championship"
+msgstr "Queda primero en el campeonato %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "¡Campeonato\n"
-        "Terminado!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"¡Campeonato\n"
+"Terminado!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "Acerca de"
+msgid "About"
+msgstr "Acerca de"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "CRÉDITOS"
+msgid "CREDITS"
+msgstr "CRÉDITOS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels es gratuito, pero puedes apoyar su\n"
-        "desarrollo de varias maneras."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels es gratuito, pero puedes apoyar su\n"
+"desarrollo de varias maneras."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "VISITA LA PÁGINA DE APOYO"
+msgid "VISIT SUPPORT PAGE"
+msgstr "VISITA LA PÁGINA DE APOYO"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Más información sobre Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "Más información sobre Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "VISITAR EL SITIO WEB"
+msgid "VISIT WEB SITE"
+msgstr "VISITAR EL SITIO WEB"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Bajo el capó"
+msgid "Under the hood"
+msgstr "Bajo el capó"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Estas opciones son principalmente interesantes para el desarrollo de Pixel Wheels, ¡pero puedes echarles un vistazo!"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Estas opciones son principalmente interesantes para el desarrollo de Pixel "
+"Wheels, ¡pero puedes echarles un vistazo!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "SECCIÓN DE LOS\n"
-        "DESARROLLADORES"
+msgid "DEV. OPTIONS"
+msgstr ""
+"SECCIÓN DE LOS\n"
+"DESARROLLADORES"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Controles"
+msgid "Controls"
+msgstr "Controles"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Jugador #%d:"
+msgid "Player #%d:"
+msgstr "Jugador #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Controles:"
+msgid "Controls:"
+msgstr "Controles:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "General"
+msgid "General"
+msgstr "General"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Idioma:"
+msgid "Language:"
+msgstr "Idioma:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Audio"
+msgid "Audio"
+msgstr "Audio"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Efectos sonoros:"
+msgid "Sound FX:"
+msgstr "Efectos sonoros:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Música:"
+msgid "Music:"
+msgstr "Música:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Vídeo"
+msgid "Video"
+msgstr "Vídeo"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Pantalla completa:"
+msgid "Fullscreen:"
+msgstr "Pantalla completa:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "CONFIGURAR"
+msgid "CONFIGURE"
+msgstr "CONFIGURAR"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "¡Gracias por jugar!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Pulsa un botón del mando..."
+msgid "Thank you for playing!"
+msgstr "¡Gracias por jugar!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Frenar"
+msgid "Brake"
+msgstr "Frenar"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Girar a la izquierda"
+msgid "Steer left"
+msgstr "Girar a la izquierda"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Girar a la derecha"
+msgid "Steer right"
+msgstr "Girar a la derecha"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Activar"
+msgid "Trigger"
+msgstr "Activar"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Alto"
+msgid "Up"
+msgstr "Alto"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Bajo"
+msgid "Down"
+msgstr "Bajo"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Izquierda"
+msgid "Left"
+msgstr "Izquierda"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Derecha"
+msgid "Right"
+msgstr "Derecha"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Activar"
+msgid "Activate"
+msgstr "Activar"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Regreso"
+msgid "Back"
+msgstr "Regreso"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Falta"
+msgid "Missing"
+msgstr "Falta"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "OK"
+msgid "OK"
+msgstr "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Jugador #%d: %s"
+msgid "Player #%d: %s"
+msgstr "Jugador #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "MENÚ PRINCIPAL"
+msgid "MAIN MENU"
+msgstr "MENÚ PRINCIPAL"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Bloqueado]"
+msgid "[Locked]"
+msgstr "[Bloqueado]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "CPU"
+msgid "CPU"
+msgstr "CPU"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "¡Nuevo vehículo desbloqueado!"
+msgid "New vehicle unlocked!"
+msgstr "¡Nuevo vehículo desbloqueado!"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "¡Nuevo campeonato desbloqueado!"
+msgid "New championship unlocked!"
+msgstr "¡Nuevo campeonato desbloqueado!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1.º"
+msgid "1st"
+msgstr "1.º"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2.º"
+msgid "2nd"
+msgstr "2.º"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3.º"
+msgid "3rd"
+msgstr "3.º"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4.º"
+msgid "4th"
+msgstr "4.º"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5.º"
+msgid "5th"
+msgstr "5.º"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6.º"
+msgid "6th"
+msgstr "6.º"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "¿Necesitas crear un informe de error? Utiliza este botón para encontrar el fichero de registro a adjuntar."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"¿Necesitas crear un informe de error? Utiliza este botón para encontrar el "
+"fichero de registro a adjuntar."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "ABRIR CARPETA DE\n"
-        "ARCHIVO DE REGISTRO"
+msgid "OPEN LOG FILE FOLDER"
+msgstr ""
+"ABRIR CARPETA DE\n"
+"ARCHIVO DE REGISTRO"
+
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Pulsa un botón del mando..."
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "Polaco :"
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "Polaco :"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "Listo !"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "Listo !"
 
 #, fuzzy
-#~ msgid        "Down | Brake:"
-#~ msgstr       "Frenar :"
+#~ msgid "Down | Brake:"
+#~ msgstr "Frenar :"
 
 #, fuzzy
-#~ msgid        "Left | Steer left:"
-#~ msgstr       "Girar a la izquierda :"
+#~ msgid "Left | Steer left:"
+#~ msgstr "Girar a la izquierda :"
 
 #, fuzzy
-#~ msgid        "Right | Steer right:"
-#~ msgstr       "Girar a la derecha :"
+#~ msgid "Right | Steer right:"
+#~ msgstr "Girar a la derecha :"
 
-#~ msgid        "OFF"
-#~ msgstr       "No"
+#~ msgid "OFF"
+#~ msgstr "No"
 
-#~ msgid        "ON"
-#~ msgstr       "Sí"
+#~ msgid "ON"
+#~ msgstr "Sí"

--- a/android/assets/po/eu.po
+++ b/android/assets/po/eu.po
@@ -3,859 +3,871 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Josu Igoa, 2022.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-05-15 11:49+0100\n"
-        "Last-Translator: Josu Igoa\n"
-        "Language-Team: Basque\n"
-        "Language: eu\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-05-15 11:49+0100\n"
+"Last-Translator: Josu Igoa\n"
+"Language-Team: Basque\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Landa Bizitza"
+msgid "Country Life"
+msgstr "Landa Bizitza"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "Ongi etorri!"
+msgid "Welcome!"
+msgstr "Ongi etorri!"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Ibaia"
+msgid "River"
+msgstr "Ibaia"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Uholdea"
+msgid "Flood"
+msgstr "Uholdea"
 
 #: android/assets/championships/1.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Mendi Karratuak"
+msgid "Square Mountains"
+msgstr "Mendi Karratuak"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Egin dezala elurra"
+msgid "Let it snow"
+msgstr "Egin dezala elurra"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "Ez irristatu!"
+msgid "Don't slip!"
+msgstr "Ez irristatu!"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "Pix Hiriak"
+msgid "Pix Cities"
+msgstr "Pix Hiriak"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Bloke herria"
+msgid "Blocky Town"
+msgstr "Bloke herria"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Tinyondo"
+msgid "Tiny sur Mer"
+msgstr "Tinyondo"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Kode irekiko lasterketa jokoa"
+msgid "An open-source racing game"
+msgstr "Kode irekiko lasterketa jokoa"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Kodea"
+msgid "Code"
+msgstr "Kodea"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Pixelak"
+msgid "Pixels"
+msgstr "Pixelak"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Musika"
+msgid "Music"
+msgstr "Musika"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Menua:"
+msgid "Menu:"
+msgstr "Menua:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Garaipena:"
+msgid "Victory:"
+msgstr "Garaipena:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Country Life txapelketa:"
+msgid "Country Life championship:"
+msgstr "Country Life txapelketa:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Square Mountains txapelketa:"
+msgid "Square Mountains championship:"
+msgstr "Square Mountains txapelketa:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Pix Cities txapelketa:"
+msgid "Pix Cities championship:"
+msgstr "Pix Cities txapelketa:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Soinu-efektuak"
+msgid "Sound Effects"
+msgstr "Soinu-efektuak"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Beste soinu-efektuak"
+msgid "Other sound effects"
+msgstr "Beste soinu-efektuak"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Letra-tipoak"
+msgid "Fonts"
+msgstr "Letra-tipoak"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Itzulpenak"
+msgid "Translations"
+msgstr "Itzulpenak"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Alemaniera:"
+msgid "German:"
+msgstr "Alemaniera:"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Christian Schrötter"
+msgid "Christian Schrötter"
+msgstr "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Espainiera:"
+msgid "Spanish:"
+msgstr "Espainiera:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Euskara:"
+msgid "Basque:"
+msgstr "Euskara:"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Frantsesa:"
+msgid "French:"
+msgstr "Frantsesa:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Poloniera:"
+msgid "Polish:"
+msgstr "Poloniera:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "Espainiera:"
+msgid "Swedish:"
+msgstr "Espainiera:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Errusiera:"
+msgid "Russian:"
+msgstr "Errusiera:"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengalera:"
+msgid "Bengali:"
+msgstr "Bengalera:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Txinera:"
+msgid "Chinese:"
+msgstr "Txinera:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Bideo edizioa"
+msgid "Video Editing"
+msgstr "Bideo edizioa"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Esker bereziak"
+msgid "Special Thanks"
+msgstr "Esker bereziak"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Guillaume Roche"
+msgid "Ethan Chapman"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Bug jakinarazle???? guztiak"
+msgid "All bug reporters"
+msgstr "Bug jakinarazle???? guztiak"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Patreon, Ko-fi eta Paypal bidezko xxxxxx guztiak"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Patreon, Ko-fi eta Paypal bidezko xxxxxx guztiak"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Honekin egina"
+msgid "Made with"
+msgstr "Honekin egina"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Jokaera aldatuko duten ezarpenak aldatu dira, puntuazioak ez dira gordeko"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Jokaera aldatuko duten ezarpenak aldatu dira, puntuazioak ez dira gordeko"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "BERRIRO HASI"
+msgid "RESTART"
+msgstr "BERRIRO HASI"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "MENURA ITZULI"
+msgid "BACK TO MENU"
+msgstr "MENURA ITZULI"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "JARRAITU"
+msgid "CONTINUE"
+msgstr "JARRAITU"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Aginte konfig"
+msgid "Gamepad config"
+msgstr "Aginte konfig"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Aktibatu:"
+msgid "Trigger:"
+msgstr "Aktibatu:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Itzuli / atzera martxa:"
+msgid "Back/reverse:"
+msgstr "Itzuli / atzera martxa:"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Teklatu konfig"
+msgid "Keyboard config"
+msgstr "Teklatu konfig"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "JOKALARI BAKARRA"
+msgid "ONE PLAYER"
+msgstr "JOKALARI BAKARRA"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "MULTIJOKALARIA"
+msgid "MULTI PLAYER"
+msgstr "MULTIJOKALARIA"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "LASTERKETA AZKARRA"
+msgid "QUICK RACE"
+msgstr "LASTERKETA AZKARRA"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "TXAPELKETA"
+msgid "CHAMPIONSHIP"
+msgstr "TXAPELKETA"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "EZARPENAK"
+msgid "SETTINGS"
+msgstr "EZARPENAK"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "IRTEN"
+msgid "QUIT"
+msgstr "IRTEN"
 
 #: android/assets/screens/multiplayer.gdxui:10
 #, fuzzy
-msgid   "Select Your Vehicles"
-msgstr  "Aukeratu zure ibiligailuak"
+msgid "Select Your Vehicles"
+msgstr "Aukeratu zure ibiligailuak"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Prest!"
+msgid "Ready!"
+msgstr "Prest!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Aginte batzuk falta dira"
+msgid "Some gamepads are missing"
+msgstr "Aginte batzuk falta dira"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Geldirik"
+msgid "Paused"
+msgstr "Geldirik"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "JARRAITU"
+msgid "RESUME"
+msgstr "JARRAITU"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "MENURA ATERA"
+msgid "QUIT TO MENU"
+msgstr "MENURA ATERA"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Aukeratu txapelketa"
+msgid "Select Championship"
+msgstr "Aukeratu txapelketa"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Joku modua aukeratu"
+msgid "Select Game Mode"
+msgstr "Joku modua aukeratu"
 
 #: android/assets/screens/selectlanguage.gdxui:5
 #, fuzzy
-msgid   "Select Language"
-msgstr  "Hizkuntza"
+msgid "Select Language"
+msgstr "Hizkuntza"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Pista aukeratu"
+msgid "Select Track"
+msgstr "Pista aukeratu"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Itzuli onena"
+msgid "Best Lap"
+msgstr "Itzuli onena"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Onena denera"
+msgid "Best Total"
+msgstr "Onena denera"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Aukeratu zure ibiligailua"
+msgid "Select Your Vehicle"
+msgstr "Aukeratu zure ibiligailua"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "2-Deuch"
+msgid "2-Deuch"
+msgstr "2-Deuch"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ant On-1"
+msgid "Ant On-1"
+msgstr "Ant On-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "M Iluna"
+msgid "Dark M"
+msgstr "M Iluna"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Uzta-makina"
+msgid "Harvester"
+msgstr "Uzta-makina"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Jeep"
+msgid "Jeep"
+msgstr "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Miramar"
+msgid "Miramar"
+msgstr "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Pickup"
+msgid "Pickup"
+msgstr "Pickup"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Autobide patruila"
+msgid "Highway Patrol"
+msgstr "Autobide patruila"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Tximista Gorria"
+msgid "Red Lightning"
+msgstr "Tximista Gorria"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Roadster"
+msgid "Roadster"
+msgstr "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Suziria"
+msgid "Rocket"
+msgstr "Suziria"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Bizarzuri Kamioia"
+msgid "Santa Truck"
+msgstr "Bizarzuri Kamioia"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Elkarbanatu"
+msgid "Share via"
+msgstr "Elkarbanatu"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Akats bat aurkitu duzu? Jakinarazi iezaguzu botoi honen bidez."
+msgid "Hit a bug? Use this button to report it."
+msgstr "Akats bat aurkitu duzu? Jakinarazi iezaguzu botoi honen bidez."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "AKATSA JAKINARAZI"
+msgid "REPORT BUG"
+msgstr "AKATSA JAKINARAZI"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Ibilgailu bat misilarekin jo"
-msgstr[1]       "%# ibilgailu misilarekin jo"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Ibilgailu bat misilarekin jo"
+msgstr[1] "%# ibilgailu misilarekin jo"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Bidetik behin irten"
-msgstr[1]       "Bidetik %# aldiz atera"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Bidetik behin irten"
+msgstr[1] "Bidetik %# aldiz atera"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Bonus bat hartu"
-msgstr[1]       "Hartu %# bonus"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Bonus bat hartu"
+msgstr[1] "Hartu %# bonus"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Agintea"
+msgid "Gamepad"
+msgstr "Agintea"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Teklatua"
+msgid "Keyboard"
+msgstr "Teklatua"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Botoiak arkuan"
+msgid "Pie buttons"
+msgstr "Botoiak arkuan"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Bazter botoiak"
+msgid "Side buttons"
+msgstr "Bazter botoiak"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Txapelketako Sailkapenak"
+msgid "Championship Rankings"
+msgstr "Txapelketako Sailkapenak"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Lasterketako Emaitzak"
+msgid "Race Results"
+msgstr "Lasterketako Emaitzak"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "Zorionak, lasterketa ederra!"
+msgid "Congratulations, great race!"
+msgstr "Zorionak, lasterketa ederra!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "Gidatze kontuetan trebea zara gero!"
+msgid "You've got some serious driving skills!"
+msgstr "Gidatze kontuetan trebea zara gero!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "Txapelduna zara!"
+msgid "You're a champ!"
+msgstr "Txapelduna zara!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "Zorionak egindako lanagatik!"
+msgid "Congrats for this performance!"
+msgstr "Zorionak egindako lanagatik!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "Izugarria!"
+msgid "Impressive!"
+msgstr "Izugarria!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  ""
+msgid "#"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Itzuli onena"
+msgid "Best lap"
+msgstr "Itzuli onena"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Gidaria"
+msgid "Racer"
+msgstr "Gidaria"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Denbora guztira"
+msgid "Total time"
+msgstr "Denbora guztira"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Puntuak"
+msgid "Points"
+msgstr "Puntuak"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Lasterketa denbora"
+msgid "Race time"
+msgstr "Lasterketa denbora"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, fuzzy, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Hirugarren edo postu hobean buka ezazu %s txapelketa"
+msgid "Finish third or better at %s championship"
+msgstr "Hirugarren edo postu hobean buka ezazu %s txapelketa"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, fuzzy, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Bigarren edo postu hobean buka ezazu %s txapelketa"
+msgid "Finish second or better at %s championship"
+msgstr "Bigarren edo postu hobean buka ezazu %s txapelketa"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, fuzzy, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Lehenengo postuan buka ezazu %s txapelketa"
+msgid "Finish first at %s championship"
+msgstr "Lehenengo postuan buka ezazu %s txapelketa"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "Txapelketa\n"
-        "Bukatu da!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"Txapelketa\n"
+"Bukatu da!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "Honi buruz"
+msgid "About"
+msgstr "Honi buruz"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "KREDITUAK"
+msgid "CREDITS"
+msgstr "KREDITUAK"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels doakoa da, baina bere garapenean\n"
-        "modu desberdinetan lagundu dezakezu."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels doakoa da, baina bere garapenean\n"
+"modu desberdinetan lagundu dezakezu."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "LAGUNTZA ORRIRA JOAN"
+msgid "VISIT SUPPORT PAGE"
+msgstr "LAGUNTZA ORRIRA JOAN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Ezagutu gehiago Pixel Wheels-i buruz"
+msgid "Learn more about Pixel Wheels"
+msgstr "Ezagutu gehiago Pixel Wheels-i buruz"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "WEBGUNERA JOAN"
+msgid "VISIT WEB SITE"
+msgstr "WEBGUNERA JOAN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Kapot azpian"
+msgid "Under the hood"
+msgstr "Kapot azpian"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Ezarpen hauek batez ere Pixel Wheels-en garapenerako dira interesgarriak, baina aldatu nahi adina!"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Ezarpen hauek batez ere Pixel Wheels-en garapenerako dira interesgarriak, "
+"baina aldatu nahi adina!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "GARAPEN AUKERAK"
+msgid "DEV. OPTIONS"
+msgstr "GARAPEN AUKERAK"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Kontrolak"
+msgid "Controls"
+msgstr "Kontrolak"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "#%d Jokalaria:"
+msgid "Player #%d:"
+msgstr "#%d Jokalaria:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Kontrolak:"
+msgid "Controls:"
+msgstr "Kontrolak:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Orokorra"
+msgid "General"
+msgstr "Orokorra"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Hizkuntza:"
+msgid "Language:"
+msgstr "Hizkuntza:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Audioa"
+msgid "Audio"
+msgstr "Audioa"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Soinu efektuak:"
+msgid "Sound FX:"
+msgstr "Soinu efektuak:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Musika:"
+msgid "Music:"
+msgstr "Musika:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Bideoa"
+msgid "Video"
+msgstr "Bideoa"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Pantaila osoa:"
+msgid "Fullscreen:"
+msgstr "Pantaila osoa:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "KONFIGURATU"
+msgid "CONFIGURE"
+msgstr "KONFIGURATU"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Eskerrik asko jostatzeagatik!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Aginteko botoi bat sakatu..."
+msgid "Thank you for playing!"
+msgstr "Eskerrik asko jostatzeagatik!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Balazta"
+msgid "Brake"
+msgstr "Balazta"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Ezkerrera biratu"
+msgid "Steer left"
+msgstr "Ezkerrera biratu"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Eskuinera biratu"
+msgid "Steer right"
+msgstr "Eskuinera biratu"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Aktibatu"
+msgid "Trigger"
+msgstr "Aktibatu"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Gora"
+msgid "Up"
+msgstr "Gora"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Behera"
+msgid "Down"
+msgstr "Behera"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Ezker"
+msgid "Left"
+msgstr "Ezker"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Eskuin"
+msgid "Right"
+msgstr "Eskuin"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Aktibatu"
+msgid "Activate"
+msgstr "Aktibatu"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Atzera"
+msgid "Back"
+msgstr "Atzera"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Faltan"
+msgid "Missing"
+msgstr "Faltan"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "ADOS"
+msgid "OK"
+msgstr "ADOS"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "#%d Jokalaria: %s"
+msgid "Player #%d: %s"
+msgstr "#%d Jokalaria: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "MENU NAGUSIA"
+msgid "MAIN MENU"
+msgstr "MENU NAGUSIA"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Blokeatua]"
+msgid "[Locked]"
+msgstr "[Blokeatua]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "PUZ"
+msgid "CPU"
+msgstr "PUZ"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "Ibilgailu berria desblokeatua!"
+msgid "New vehicle unlocked!"
+msgstr "Ibilgailu berria desblokeatua!"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "Txapelketa berria desblokeatua!"
+msgid "New championship unlocked!"
+msgstr "Txapelketa berria desblokeatua!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1."
+msgid "1st"
+msgstr "1."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2."
+msgid "2nd"
+msgstr "2."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3."
+msgid "3rd"
+msgstr "3."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4."
+msgid "4th"
+msgstr "4."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5."
+msgid "5th"
+msgstr "5."
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6."
+msgid "6th"
+msgstr "6."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Fitxategia behar duzu akatsa jakinarazteko? Erabili botoi hau beharrezko fitxategia bilatzeko."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Fitxategia behar duzu akatsa jakinarazteko? Erabili botoi hau beharrezko "
+"fitxategia bilatzeko."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "LOG-EN KARPETA IREKI"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "LOG-EN KARPETA IREKI"
+
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Aginteko botoi bat sakatu..."
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "Polizia"
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "Polizia"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "Gorria"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "Gorria"

--- a/android/assets/po/fr.po
+++ b/android/assets/po/fr.po
@@ -1,895 +1,909 @@
 # Aurélien Gâteau <mail@agateau.com>, 2022.
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: \n"
-        "PO-Revision-Date: 2022-07-03 17:57+0200\n"
-        "Last-Translator: Aurélien Gâteau <mail@agateau.com>\n"
-        "Language-Team: French\n"
-        "Language: fr_FR\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-        "X-Generator: Poedit 2.3\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2022-07-03 17:57+0200\n"
+"Last-Translator: Aurélien Gâteau <mail@agateau.com>\n"
+"Language-Team: French\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "La vie à la campagne"
+msgid "Country Life"
+msgstr "La vie à la campagne"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "Bienvenue !"
+msgid "Welcome!"
+msgstr "Bienvenue !"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Rivière"
+msgid "River"
+msgstr "Rivière"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Inondation"
+msgid "Flood"
+msgstr "Inondation"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Les Monts Carrés"
+msgid "Square Mountains"
+msgstr "Les Monts Carrés"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Vive le vent d'hiver"
+msgid "Let it snow"
+msgstr "Vive le vent d'hiver"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "Attention, sol glissant !"
+msgid "Don't slip!"
+msgstr "Attention, sol glissant !"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "La cité des pixels"
+msgid "Pix Cities"
+msgstr "La cité des pixels"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Blocville"
+msgid "Blocky Town"
+msgstr "Blocville"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Tiny sur Mer"
+msgid "Tiny sur Mer"
+msgstr "Tiny sur Mer"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Un jeu de course open-source"
+msgid "An open-source racing game"
+msgstr "Un jeu de course open-source"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Code"
+msgid "Code"
+msgstr "Code"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Pixels"
+msgid "Pixels"
+msgstr "Pixels"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Musique"
+msgid "Music"
+msgstr "Musique"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Menu :"
+msgid "Menu:"
+msgstr "Menu :"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Victoire :"
+msgid "Victory:"
+msgstr "Victoire :"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Championnat La vie à la campagne :"
+msgid "Country Life championship:"
+msgstr "Championnat La vie à la campagne :"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Championnat Les Monts Carrés :"
+msgid "Square Mountains championship:"
+msgstr "Championnat Les Monts Carrés :"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Championnat La cité des pixels :"
+msgid "Pix Cities championship:"
+msgstr "Championnat La cité des pixels :"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Effets sonores"
+msgid "Sound Effects"
+msgstr "Effets sonores"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Autres effets sonores"
+msgid "Other sound effects"
+msgstr "Autres effets sonores"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Polices"
+msgid "Fonts"
+msgstr "Polices"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Traductions"
+msgid "Translations"
+msgstr "Traductions"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Allemand :"
+msgid "German:"
+msgstr "Allemand :"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Christian Schrötter"
+msgid "Christian Schrötter"
+msgstr "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Espagnol :"
+msgid "Spanish:"
+msgstr "Espagnol :"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Basque :"
+msgid "Basque:"
+msgstr "Basque :"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Français :"
+msgid "French:"
+msgstr "Français :"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Polonais:"
+msgid "Polish:"
+msgstr "Polonais:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "Espagnol :"
+msgid "Swedish:"
+msgstr "Espagnol :"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Russe :"
+msgid "Russian:"
+msgstr "Russe :"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengali :"
+msgid "Bengali:"
+msgstr "Bengali :"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Chinois :"
+msgid "Chinese:"
+msgstr "Chinois :"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Édition vidéo"
+msgid "Video Editing"
+msgstr "Édition vidéo"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Merci à"
+msgid "Special Thanks"
+msgstr "Merci à"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Les rapporteurs de bug"
+msgid "All bug reporters"
+msgstr "Les rapporteurs de bug"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Les soutiens sur Patreon, Ko-fi et Paypal"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Les soutiens sur Patreon, Ko-fi et Paypal"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Créé avec"
+msgid "Made with"
+msgstr "Créé avec"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Des réglages affectant la jouabilité ont été modifiés, les scores ne seront pas sauvegardés"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Des réglages affectant la jouabilité ont été modifiés, les scores ne seront "
+"pas sauvegardés"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "RECOMMENCER"
+msgid "RESTART"
+msgstr "RECOMMENCER"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "RETOUR"
+msgid "BACK TO MENU"
+msgstr "RETOUR"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "CONTINUER"
+msgid "CONTINUE"
+msgstr "CONTINUER"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Configuration manette"
+msgid "Gamepad config"
+msgstr "Configuration manette"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Activer :"
+msgid "Trigger:"
+msgstr "Activer :"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Retour / marche arrière :"
+msgid "Back/reverse:"
+msgstr "Retour / marche arrière :"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Configuration du clavier"
+msgid "Keyboard config"
+msgstr "Configuration du clavier"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "UN JOUEUR"
+msgid "ONE PLAYER"
+msgstr "UN JOUEUR"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "MULTI-JOUEURS"
+msgid "MULTI PLAYER"
+msgstr "MULTI-JOUEURS"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "COURSE RAPIDE"
+msgid "QUICK RACE"
+msgstr "COURSE RAPIDE"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "CHAMPIONNAT"
+msgid "CHAMPIONSHIP"
+msgstr "CHAMPIONNAT"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "CONFIGURATION"
+msgid "SETTINGS"
+msgstr "CONFIGURATION"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "QUITTER"
+msgid "QUIT"
+msgstr "QUITTER"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid   "Select Your Vehicles"
-msgstr  "Choisissez vos véhicules"
+msgid "Select Your Vehicles"
+msgstr "Choisissez vos véhicules"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Prêt !"
+msgid "Ready!"
+msgstr "Prêt !"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Certaines manettes sont manquantes"
+msgid "Some gamepads are missing"
+msgstr "Certaines manettes sont manquantes"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Pause"
+msgid "Paused"
+msgstr "Pause"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "CONTINUER"
+msgid "RESUME"
+msgstr "CONTINUER"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "RETOUR AU MENU"
+msgid "QUIT TO MENU"
+msgstr "RETOUR AU MENU"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Choisissez un championnat"
+msgid "Select Championship"
+msgstr "Choisissez un championnat"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Choisissez le mode de jeu"
+msgid "Select Game Mode"
+msgstr "Choisissez le mode de jeu"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid   "Select Language"
-msgstr  "Sélectionnez la langue"
+msgid "Select Language"
+msgstr "Sélectionnez la langue"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Choisissez une piste"
+msgid "Select Track"
+msgstr "Choisissez une piste"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Meilleur tour"
+msgid "Best Lap"
+msgstr "Meilleur tour"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Meilleur temps total"
+msgid "Best Total"
+msgstr "Meilleur temps total"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Choisissez votre véhicule"
+msgid "Select Your Vehicle"
+msgstr "Choisissez votre véhicule"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "2-Deuch"
+msgid "2-Deuch"
+msgstr "2-Deuch"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ant On-1"
+msgid "Ant On-1"
+msgstr "Ant On-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "Dark M"
+msgid "Dark M"
+msgstr "Dark M"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Moiss-batt"
+msgid "Harvester"
+msgstr "Moiss-batt"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Jeep"
+msgid "Jeep"
+msgstr "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Miramar"
+msgid "Miramar"
+msgstr "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Pickup"
+msgid "Pickup"
+msgstr "Pickup"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Highway Patrol"
+msgid "Highway Patrol"
+msgstr "Highway Patrol"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Red Lightning"
+msgid "Red Lightning"
+msgstr "Red Lightning"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Roadster"
+msgid "Roadster"
+msgstr "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Roquette"
+msgid "Rocket"
+msgstr "Roquette"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Camion de Noël"
+msgid "Santa Truck"
+msgstr "Camion de Noël"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Partager via"
+msgid "Share via"
+msgstr "Partager via"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Vous avez trouvé un bug ? Utiliser ce bouton pour le rapporter."
+msgid "Hit a bug? Use this button to report it."
+msgstr "Vous avez trouvé un bug ? Utiliser ce bouton pour le rapporter."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "RAPPORTER UN BUG"
+msgid "REPORT BUG"
+msgstr "RAPPORTER UN BUG"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Toucher un véhicule avec un missile"
-msgstr[1]       "Toucher %# véhicules avec un missile"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Toucher un véhicule avec un missile"
+msgstr[1] "Toucher %# véhicules avec un missile"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Quitter la route une fois"
-msgstr[1]       "Quitter la route %# fois"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Quitter la route une fois"
+msgstr[1] "Quitter la route %# fois"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Attraper un bonus"
-msgstr[1]       "Attraper %# bonus"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Attraper un bonus"
+msgstr[1] "Attraper %# bonus"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Manette"
+msgid "Gamepad"
+msgstr "Manette"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Clavier"
+msgid "Keyboard"
+msgstr "Clavier"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Boutons en arc"
+msgid "Pie buttons"
+msgstr "Boutons en arc"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Boutons sur les côtés"
+msgid "Side buttons"
+msgstr "Boutons sur les côtés"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Classement du championnat"
+msgid "Championship Rankings"
+msgstr "Classement du championnat"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Résultats de la course"
+msgid "Race Results"
+msgstr "Résultats de la course"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "Félicitations, superbe course !"
+msgid "Congratulations, great race!"
+msgstr "Félicitations, superbe course !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "Vous êtes un sacré pilote !"
+msgid "You've got some serious driving skills!"
+msgstr "Vous êtes un sacré pilote !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "Champion !"
+msgid "You're a champ!"
+msgstr "Champion !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "Bravo pour cette performance !"
+msgid "Congrats for this performance!"
+msgstr "Bravo pour cette performance !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "Impressionnant !"
+msgid "Impressive!"
+msgstr "Impressionnant !"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "N°"
+msgid "#"
+msgstr "N°"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Meilleur tour"
+msgid "Best lap"
+msgstr "Meilleur tour"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Pilote"
+msgid "Racer"
+msgstr "Pilote"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Temps total"
+msgid "Total time"
+msgstr "Temps total"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Points"
+msgid "Points"
+msgstr "Points"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Temps de course"
+msgid "Race time"
+msgstr "Temps de course"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Arriver 3e ou mieux au championnat %s"
+msgid "Finish third or better at %s championship"
+msgstr "Arriver 3e ou mieux au championnat %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Arriver 2e ou mieux au championnat %s"
+msgid "Finish second or better at %s championship"
+msgstr "Arriver 2e ou mieux au championnat %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Arriver 1er au championnat %s"
+msgid "Finish first at %s championship"
+msgstr "Arriver 1er au championnat %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "Championnat\n"
-        "terminé !"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"Championnat\n"
+"terminé !"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "À propos"
+msgid "About"
+msgstr "À propos"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "CRÉDITS"
+msgid "CREDITS"
+msgstr "CRÉDITS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels est gratuit, mais vous pouvez soutenir son développement de plusieurs façons."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels est gratuit, mais vous pouvez soutenir son développement de "
+"plusieurs façons."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "PAGE DE SOUTIEN"
+msgid "VISIT SUPPORT PAGE"
+msgstr "PAGE DE SOUTIEN"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "En apprendre plus sur Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "En apprendre plus sur Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "SITE WEB"
+msgid "VISIT WEB SITE"
+msgstr "SITE WEB"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Sous le capot"
+msgid "Under the hood"
+msgstr "Sous le capot"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Ces options sont surtout intéressantes pour le développement de Pixel Wheels, mais vous pouvez y faire un tour !"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Ces options sont surtout intéressantes pour le développement de Pixel "
+"Wheels, mais vous pouvez y faire un tour !"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "COIN DES DEVS"
+msgid "DEV. OPTIONS"
+msgstr "COIN DES DEVS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Contrôles"
+msgid "Controls"
+msgstr "Contrôles"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Joueur n°%d :"
+msgid "Player #%d:"
+msgstr "Joueur n°%d :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Contrôles :"
+msgid "Controls:"
+msgstr "Contrôles :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Général"
+msgid "General"
+msgstr "Général"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Langue :"
+msgid "Language:"
+msgstr "Langue :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Audio"
+msgid "Audio"
+msgstr "Audio"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Effets sonores :"
+msgid "Sound FX:"
+msgstr "Effets sonores :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Musique :"
+msgid "Music:"
+msgstr "Musique :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Vidéo"
+msgid "Video"
+msgstr "Vidéo"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Plein écran :"
+msgid "Fullscreen:"
+msgstr "Plein écran :"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "CONFIGURER"
+msgid "CONFIGURE"
+msgstr "CONFIGURER"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Merci d'avoir joué !"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Pressez une touche de la manette..."
+msgid "Thank you for playing!"
+msgstr "Merci d'avoir joué !"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Freiner"
+msgid "Brake"
+msgstr "Freiner"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Tourner à gauche"
+msgid "Steer left"
+msgstr "Tourner à gauche"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Tourner à droite"
+msgid "Steer right"
+msgstr "Tourner à droite"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Activer"
+msgid "Trigger"
+msgstr "Activer"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Haut"
+msgid "Up"
+msgstr "Haut"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Bas"
+msgid "Down"
+msgstr "Bas"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Gauche"
+msgid "Left"
+msgstr "Gauche"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Droite"
+msgid "Right"
+msgstr "Droite"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Activer"
+msgid "Activate"
+msgstr "Activer"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Retour"
+msgid "Back"
+msgstr "Retour"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Manquant"
+msgid "Missing"
+msgstr "Manquant"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "OK"
+msgid "OK"
+msgstr "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Joueur n°%d : %s"
+msgid "Player #%d: %s"
+msgstr "Joueur n°%d : %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "MENU PRINCIPAL"
+msgid "MAIN MENU"
+msgstr "MENU PRINCIPAL"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Verrouillé]"
+msgid "[Locked]"
+msgstr "[Verrouillé]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "CPU"
+msgid "CPU"
+msgstr "CPU"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "Nouveau véhicule débloqué !"
+msgid "New vehicle unlocked!"
+msgstr "Nouveau véhicule débloqué !"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "Nouveau championnat débloqué !"
+msgid "New championship unlocked!"
+msgstr "Nouveau championnat débloqué !"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1er"
+msgid "1st"
+msgstr "1er"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2e"
+msgid "2nd"
+msgstr "2e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3e"
+msgid "3rd"
+msgstr "3e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4e"
+msgid "4th"
+msgstr "4e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5e"
+msgid "5th"
+msgstr "5e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6e"
+msgid "6th"
+msgstr "6e"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Besoin de créer un rapport de bug ? Utilisez ce bouton pour trouver le fichier de log à attacher."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Besoin de créer un rapport de bug ? Utilisez ce bouton pour trouver le "
+"fichier de log à attacher."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "DOSSIER DES LOGS"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "DOSSIER DES LOGS"
+
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Pressez une touche de la manette..."
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "Polonais:"
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "Polonais:"
 
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "Rouge"
-
-#, fuzzy
-#~ msgid        "Down | Brake:"
-#~ msgstr       "Freiner :"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "Rouge"
 
 #, fuzzy
-#~ msgid        "Left | Steer left:"
-#~ msgstr       "Tourner à gauche :"
+#~ msgid "Down | Brake:"
+#~ msgstr "Freiner :"
 
 #, fuzzy
-#~ msgid        "Right | Steer right:"
-#~ msgstr       "Tourner à droite :"
+#~ msgid "Left | Steer left:"
+#~ msgstr "Tourner à gauche :"
 
-#~ msgid        "OFF"
-#~ msgstr       "Non"
+#, fuzzy
+#~ msgid "Right | Steer right:"
+#~ msgstr "Tourner à droite :"
 
-#~ msgid        "ON"
-#~ msgstr       "Oui"
+#~ msgid "OFF"
+#~ msgstr "Non"
 
-#~ msgid        "Finished!"
-#~ msgstr       "terminé !"
+#~ msgid "ON"
+#~ msgstr "Oui"
 
-#~ msgid        "Beta Testers"
-#~ msgstr       "Bêta testeurs"
+#~ msgid "Finished!"
+#~ msgstr "terminé !"
 
-#~ msgid        "(thank you!)"
-#~ msgstr       "(merci !)"
+#~ msgid "Beta Testers"
+#~ msgstr "Bêta testeurs"
 
-#~ msgid        "Internal"
-#~ msgstr       "Interne"
+#~ msgid "(thank you!)"
+#~ msgstr "(merci !)"
 
-#~ msgid        "Audio & Video"
-#~ msgstr       "Audio & Vidéo"
+#~ msgid "Internal"
+#~ msgstr "Interne"
 
-#~ msgid        "Others"
-#~ msgstr       "Autres"
+#~ msgid "Audio & Video"
+#~ msgstr "Audio & Vidéo"
 
-#~ msgid        "Player %d:"
-#~ msgstr       "Joueur n°%d  :"
+#~ msgid "Others"
+#~ msgstr "Autres"
 
-#~ msgid        "%s:"
-#~ msgstr       "%s :"
+#~ msgid "Player %d:"
+#~ msgstr "Joueur n°%d  :"
+
+#~ msgid "%s:"
+#~ msgstr "%s :"

--- a/android/assets/po/messages.pot
+++ b/android/assets/po/messages.pot
@@ -733,10 +733,6 @@ msgstr ""
 msgid "Thank you for playing!"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid "Press the gamepad key..."
-msgstr ""
-
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
 msgid "Brake"

--- a/android/assets/po/pl.po
+++ b/android/assets/po/pl.po
@@ -1,880 +1,893 @@
 # PandaCoderPL <translator@pandacoderpl.anonaddy.me>, 2022.
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-05-15 10:30+0000\n"
-        "Last-Translator: PandaCoderPL <translator@pandacoderpl.anonaddy.me>\n"
-        "Language-Team: Polish\n"
-        "Language: pl_PL\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-05-15 10:30+0000\n"
+"Last-Translator: PandaCoderPL <translator@pandacoderpl.anonaddy.me>\n"
+"Language-Team: Polish\n"
+"Language: pl_PL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Mistrzostwa Country Life:"
+msgid "Country Life"
+msgstr "Mistrzostwa Country Life:"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  ""
+msgid "Welcome!"
+msgstr ""
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  ""
+msgid "River"
+msgstr ""
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  ""
+msgid "Flood"
+msgstr ""
 
 #: android/assets/championships/1.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Mistrzostwa Square Mountains:"
+msgid "Square Mountains"
+msgstr "Mistrzostwa Square Mountains:"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  ""
+msgid "Let it snow"
+msgstr ""
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  ""
+msgid "Don't slip!"
+msgstr ""
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  ""
+msgid "Pix Cities"
+msgstr ""
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  ""
+msgid "Blocky Town"
+msgstr ""
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  ""
+msgid "Tiny sur Mer"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Otwartoźródłowa gra wyścigowa"
+msgid "An open-source racing game"
+msgstr "Otwartoźródłowa gra wyścigowa"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Kod"
+msgid "Code"
+msgstr "Kod"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Piksele"
+msgid "Pixels"
+msgstr "Piksele"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Muzyka"
+msgid "Music"
+msgstr "Muzyka"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Menu:"
+msgid "Menu:"
+msgstr "Menu:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Wygrana:"
+msgid "Victory:"
+msgstr "Wygrana:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Mistrzostwa Country Life:"
+msgid "Country Life championship:"
+msgstr "Mistrzostwa Country Life:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Mistrzostwa Square Mountains:"
+msgid "Square Mountains championship:"
+msgstr "Mistrzostwa Square Mountains:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Mistrzostwa Pix Cities:"
+msgid "Pix Cities championship:"
+msgstr "Mistrzostwa Pix Cities:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Efekty Dźwiękowe"
+msgid "Sound Effects"
+msgstr "Efekty Dźwiękowe"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Inne efekty dźwiękowe"
+msgid "Other sound effects"
+msgstr "Inne efekty dźwiękowe"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Czcionki"
+msgid "Fonts"
+msgstr "Czcionki"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Tłumaczenia"
+msgid "Translations"
+msgstr "Tłumaczenia"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  ""
+msgid "German:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  ""
+msgid "Christian Schrötter"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Hiszpański:"
+msgid "Spanish:"
+msgstr "Hiszpański:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  ""
+msgid "Basque:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  ""
+msgid "Josu Igoa"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Francuski:"
+msgid "French:"
+msgstr "Francuski:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Polski:"
+msgid "Polish:"
+msgstr "Polski:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "Hiszpański:"
+msgid "Swedish:"
+msgstr "Hiszpański:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  ""
+msgid "Russian:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  ""
+msgid "Nickoriginal"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengalski:"
+msgid "Bengali:"
+msgstr "Bengalski:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Chiński:"
+msgid "Chinese:"
+msgstr "Chiński:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Edycja Wideo"
+msgid "Video Editing"
+msgstr "Edycja Wideo"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Specjalne Podziękowania"
+msgid "Special Thanks"
+msgstr "Specjalne Podziękowania"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Wszystkie osoby zgłaszające błędy"
+msgid "All bug reporters"
+msgstr "Wszystkie osoby zgłaszające błędy"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Wszyscy wspierający na Patreonie, Ko-fi i Paypalu"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Wszyscy wspierający na Patreonie, Ko-fi i Paypalu"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Zrobione używając"
+msgid "Made with"
+msgstr "Zrobione używając"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Ustawienia wpływające na rozgrywkę zostały zmienione, wyniki nie będą zapisywane"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Ustawienia wpływające na rozgrywkę zostały zmienione, wyniki nie będą "
+"zapisywane"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "RESTART"
+msgid "RESTART"
+msgstr "RESTART"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "POWRÓT DO MENU"
+msgid "BACK TO MENU"
+msgstr "POWRÓT DO MENU"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "KONTYNUUJ"
+msgid "CONTINUE"
+msgstr "KONTYNUUJ"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Konfiguracja kontrolera"
+msgid "Gamepad config"
+msgstr "Konfiguracja kontrolera"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Spust:"
+msgid "Trigger:"
+msgstr "Spust:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Wstecz/w tył:"
+msgid "Back/reverse:"
+msgstr "Wstecz/w tył:"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Konfiguracja klawiatury"
+msgid "Keyboard config"
+msgstr "Konfiguracja klawiatury"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "JEDEN GRACZ"
+msgid "ONE PLAYER"
+msgstr "JEDEN GRACZ"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "WIELU GRACZY"
+msgid "MULTI PLAYER"
+msgstr "WIELU GRACZY"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "SZYBKI WYŚCIG"
+msgid "QUICK RACE"
+msgstr "SZYBKI WYŚCIG"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "MISTRZOSTWA"
+msgid "CHAMPIONSHIP"
+msgstr "MISTRZOSTWA"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "USTAWIENIA"
+msgid "SETTINGS"
+msgstr "USTAWIENIA"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "WYJDŹ"
+msgid "QUIT"
+msgstr "WYJDŹ"
 
 #: android/assets/screens/multiplayer.gdxui:10
 #, fuzzy
-msgid   "Select Your Vehicles"
-msgstr  "Wybierz Swój Pojazd"
+msgid "Select Your Vehicles"
+msgstr "Wybierz Swój Pojazd"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Gotowy!"
+msgid "Ready!"
+msgstr "Gotowy!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Brakuje niektórych kontrolerów"
+msgid "Some gamepads are missing"
+msgstr "Brakuje niektórych kontrolerów"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Zapauzowano"
+msgid "Paused"
+msgstr "Zapauzowano"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "WZNÓW"
+msgid "RESUME"
+msgstr "WZNÓW"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "WYJDŹ DO MENU"
+msgid "QUIT TO MENU"
+msgstr "WYJDŹ DO MENU"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Wybierz Mistrzostwa"
+msgid "Select Championship"
+msgstr "Wybierz Mistrzostwa"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Wybierz Tryb Gry"
+msgid "Select Game Mode"
+msgstr "Wybierz Tryb Gry"
 
 #: android/assets/screens/selectlanguage.gdxui:5
 #, fuzzy
-msgid   "Select Language"
-msgstr  "Język:"
+msgid "Select Language"
+msgstr "Język:"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Wybierz Tor"
+msgid "Select Track"
+msgstr "Wybierz Tor"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Najlepsze Okrążenie"
+msgid "Best Lap"
+msgstr "Najlepsze Okrążenie"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Najlepszy Czas"
+msgid "Best Total"
+msgstr "Najlepszy Czas"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Wybierz Swój Pojazd"
+msgid "Select Your Vehicle"
+msgstr "Wybierz Swój Pojazd"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  ""
+msgid "2-Deuch"
+msgstr ""
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  ""
+msgid "Ant On-1"
+msgstr ""
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  ""
+msgid "Dark M"
+msgstr ""
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  ""
+msgid "Harvester"
+msgstr ""
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  ""
+msgid "Jeep"
+msgstr ""
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  ""
+msgid "Miramar"
+msgstr ""
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  ""
+msgid "Pickup"
+msgstr ""
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  ""
+msgid "Highway Patrol"
+msgstr ""
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  ""
+msgid "Red Lightning"
+msgstr ""
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  ""
+msgid "Roadster"
+msgstr ""
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  ""
+msgid "Rocket"
+msgstr ""
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  ""
+msgid "Santa Truck"
+msgstr ""
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Udostępnij przez"
+msgid "Share via"
+msgstr "Udostępnij przez"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Natrafiłeś na błąd? Użyj tego przycisku, żeby go zgłosić."
+msgid "Hit a bug? Use this button to report it."
+msgstr "Natrafiłeś na błąd? Użyj tego przycisku, żeby go zgłosić."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "ZGŁOŚ BŁĄD"
+msgid "REPORT BUG"
+msgstr "ZGŁOŚ BŁĄD"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Traf jeden pojazd używając pocisku"
-msgstr[1]       "Traf %# pojazdy używając pocisku"
-msgstr[2]       "Traf %# pojazdów używając pocisku"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Traf jeden pojazd używając pocisku"
+msgstr[1] "Traf %# pojazdy używając pocisku"
+msgstr[2] "Traf %# pojazdów używając pocisku"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Opuść drogę jeden raz"
-msgstr[1]       "Opuść drogę %# razy"
-msgstr[2]       "Opuść drogę %# razy"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Opuść drogę jeden raz"
+msgstr[1] "Opuść drogę %# razy"
+msgstr[2] "Opuść drogę %# razy"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Zbierz jedną premię"
-msgstr[1]       "Zbierz %# premie"
-msgstr[2]       "Zbierz %# premii"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Zbierz jedną premię"
+msgstr[1] "Zbierz %# premie"
+msgstr[2] "Zbierz %# premii"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Kontroler"
+msgid "Gamepad"
+msgstr "Kontroler"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Klawiatura"
+msgid "Keyboard"
+msgstr "Klawiatura"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Przyciski kołowe"
+msgid "Pie buttons"
+msgstr "Przyciski kołowe"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Boczne przyciski"
+msgid "Side buttons"
+msgstr "Boczne przyciski"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Rankingi Mistrzostw"
+msgid "Championship Rankings"
+msgstr "Rankingi Mistrzostw"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Wyniki Wyścigów"
+msgid "Race Results"
+msgstr "Wyniki Wyścigów"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
 #, fuzzy
-msgid   "Congratulations, great race!"
-msgstr  "Gratulacje!\n"
-        "Pobiłeś rekord!"
+msgid "Congratulations, great race!"
+msgstr ""
+"Gratulacje!\n"
+"Pobiłeś rekord!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  ""
+msgid "You've got some serious driving skills!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  ""
+msgid "You're a champ!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  ""
+msgid "Congrats for this performance!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  ""
+msgid "Impressive!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "#"
+msgid "#"
+msgstr "#"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Najlepsze okrążenie"
+msgid "Best lap"
+msgstr "Najlepsze okrążenie"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Zawodnik"
+msgid "Racer"
+msgstr "Zawodnik"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Łączny czas"
+msgid "Total time"
+msgstr "Łączny czas"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Punkty"
+msgid "Points"
+msgstr "Punkty"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Czas wyścigu"
+msgid "Race time"
+msgstr "Czas wyścigu"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, fuzzy, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Pozycja 3 lub lepsza na mistrzostwach %s"
+msgid "Finish third or better at %s championship"
+msgstr "Pozycja 3 lub lepsza na mistrzostwach %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, fuzzy, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Pozycja 3 lub lepsza na mistrzostwach %s"
+msgid "Finish second or better at %s championship"
+msgstr "Pozycja 3 lub lepsza na mistrzostwach %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, fuzzy, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Pozycja 3 lub lepsza na mistrzostwach %s"
+msgid "Finish first at %s championship"
+msgstr "Pozycja 3 lub lepsza na mistrzostwach %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "Mistrzostwa\n"
-        "Zakończone!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"Mistrzostwa\n"
+"Zakończone!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "O"
+msgid "About"
+msgstr "O"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "CREDITS"
+msgid "CREDITS"
+msgstr "CREDITS"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels jest darmowe, ale możesz wesprzeć jego\n"
-        "rozwój na różne sposoby."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels jest darmowe, ale możesz wesprzeć jego\n"
+"rozwój na różne sposoby."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "ODWIEDŹ STRONĘ WSPARCIA"
+msgid "VISIT SUPPORT PAGE"
+msgstr "ODWIEDŹ STRONĘ WSPARCIA"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Naucz się więcej o Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "Naucz się więcej o Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "ODWIEDŹ STRONĘ"
+msgid "VISIT WEB SITE"
+msgstr "ODWIEDŹ STRONĘ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Pod maską"
+msgid "Under the hood"
+msgstr "Pod maską"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Te opcje są głównie interesujące dla rozwoju Pixel Wheels, ale nie bój się ich wypróbować!"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Te opcje są głównie interesujące dla rozwoju Pixel Wheels, ale nie bój się "
+"ich wypróbować!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "OPCJE DEW."
+msgid "DEV. OPTIONS"
+msgstr "OPCJE DEW."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Sterowanie"
+msgid "Controls"
+msgstr "Sterowanie"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Gracz #%d:"
+msgid "Player #%d:"
+msgstr "Gracz #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Sterowanie:"
+msgid "Controls:"
+msgstr "Sterowanie:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Ogólne"
+msgid "General"
+msgstr "Ogólne"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Język:"
+msgid "Language:"
+msgstr "Język:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Dźwięk"
+msgid "Audio"
+msgstr "Dźwięk"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Efekty dźwiękowe:"
+msgid "Sound FX:"
+msgstr "Efekty dźwiękowe:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Muzyka:"
+msgid "Music:"
+msgstr "Muzyka:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Wideo"
+msgid "Video"
+msgstr "Wideo"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Pełny ekran:"
+msgid "Fullscreen:"
+msgstr "Pełny ekran:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "KONFIGURUJ"
+msgid "CONFIGURE"
+msgstr "KONFIGURUJ"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Dziękuję z granie!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  ""
+msgid "Thank you for playing!"
+msgstr "Dziękuję z granie!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
 #, fuzzy
-msgid   "Brake"
-msgstr  "Hamulec:"
+msgid "Brake"
+msgstr "Hamulec:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
 #, fuzzy
-msgid   "Steer left"
-msgstr  "Skręć w lewo:"
+msgid "Steer left"
+msgstr "Skręć w lewo:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
 #, fuzzy
-msgid   "Steer right"
-msgstr  "Skręć w prawo:"
+msgid "Steer right"
+msgstr "Skręć w prawo:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
 #, fuzzy
-msgid   "Trigger"
-msgstr  "Spust:"
+msgid "Trigger"
+msgstr "Spust:"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  ""
+msgid "Up"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  ""
+msgid "Down"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  ""
+msgid "Left"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  ""
+msgid "Right"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  ""
+msgid "Activate"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  ""
+msgid "Back"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Brakujące"
+msgid "Missing"
+msgstr "Brakujące"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "OK"
+msgid "OK"
+msgstr "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Gracz #%d: %s"
+msgid "Player #%d: %s"
+msgstr "Gracz #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "MENU GŁÓWNE"
+msgid "MAIN MENU"
+msgstr "MENU GŁÓWNE"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Zablokowane]"
+msgid "[Locked]"
+msgstr "[Zablokowane]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  ""
+msgid "CPU"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  ""
+msgid "New vehicle unlocked!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
 #, fuzzy
-msgid   "New championship unlocked!"
-msgstr  "Mistrzostwa\n"
-        "Zakończone!"
+msgid "New championship unlocked!"
+msgstr ""
+"Mistrzostwa\n"
+"Zakończone!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1st"
+msgid "1st"
+msgstr "1st"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2nd"
+msgid "2nd"
+msgstr "2nd"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3rd"
+msgid "3rd"
+msgstr "3rd"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4th"
+msgid "4th"
+msgstr "4th"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5th"
+msgid "5th"
+msgstr "5th"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6th"
+msgid "6th"
+msgstr "6th"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Potrzebujesz zgłosić błąd? Użyj tego przycisku, żeby znaleźć logi do dołączenia."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Potrzebujesz zgłosić błąd? Użyj tego przycisku, żeby znaleźć logi do "
+"dołączenia."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "OTWÓRZ FOLDER Z LOGAMI"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "OTWÓRZ FOLDER Z LOGAMI"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "Polski:"
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "Polski:"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "Gotowy!"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "Gotowy!"
 
 #, fuzzy
-#~ msgid        "Down | Brake:"
-#~ msgstr       "Hamulec:"
+#~ msgid "Down | Brake:"
+#~ msgstr "Hamulec:"
 
 #, fuzzy
-#~ msgid        "Left | Steer left:"
-#~ msgstr       "Skręć w lewo:"
+#~ msgid "Left | Steer left:"
+#~ msgstr "Skręć w lewo:"
 
 #, fuzzy
-#~ msgid        "Right | Steer right:"
-#~ msgstr       "Skręć w prawo:"
+#~ msgid "Right | Steer right:"
+#~ msgstr "Skręć w prawo:"

--- a/android/assets/po/ru.po
+++ b/android/assets/po/ru.po
@@ -3,848 +3,862 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Nickoriginal, 2022.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-06-01 11:11+0200\n"
-        "Last-Translator: Nickoriginal\n"
-        "Language-Team: Russian\n"
-        "Language: ru\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-06-01 11:11+0200\n"
+"Last-Translator: Nickoriginal\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Сельская жизнь"
+msgid "Country Life"
+msgstr "Сельская жизнь"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "Добро пожаловать!"
+msgid "Welcome!"
+msgstr "Добро пожаловать!"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Река"
+msgid "River"
+msgstr "Река"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Потоп"
+msgid "Flood"
+msgstr "Потоп"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Квадратные горы"
+msgid "Square Mountains"
+msgstr "Квадратные горы"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Пусть идёт снег"
+msgid "Let it snow"
+msgstr "Пусть идёт снег"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "Не поскользнись!"
+msgid "Don't slip!"
+msgstr "Не поскользнись!"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "Пиксельные города"
+msgid "Pix Cities"
+msgstr "Пиксельные города"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Блочный городок"
+msgid "Blocky Town"
+msgstr "Блочный городок"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Колёса у моря"
+msgid "Tiny sur Mer"
+msgstr "Колёса у моря"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Гоночная игра с открытым исходным кодом"
+msgid "An open-source racing game"
+msgstr "Гоночная игра с открытым исходным кодом"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Код"
+msgid "Code"
+msgstr "Код"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Пиксели"
+msgid "Pixels"
+msgstr "Пиксели"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Музыка"
+msgid "Music"
+msgstr "Музыка"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Меню:"
+msgid "Menu:"
+msgstr "Меню:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Томас Трипон"
+msgid "Thomas Tripon"
+msgstr "Томас Трипон"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Победа:"
+msgid "Victory:"
+msgstr "Победа:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Чемпионат Сельская жизнь:"
+msgid "Country Life championship:"
+msgstr "Чемпионат Сельская жизнь:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Чемпионат Квадратные горы:"
+msgid "Square Mountains championship:"
+msgstr "Чемпионат Квадратные горы:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Чемпионат Пиксельные города:"
+msgid "Pix Cities championship:"
+msgstr "Чемпионат Пиксельные города:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Звуковые эффекты"
+msgid "Sound Effects"
+msgstr "Звуковые эффекты"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Другие звуковые эффекты"
+msgid "Other sound effects"
+msgstr "Другие звуковые эффекты"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Шрифты"
+msgid "Fonts"
+msgstr "Шрифты"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Переводы"
+msgid "Translations"
+msgstr "Переводы"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Немецкий:"
+msgid "German:"
+msgstr "Немецкий:"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Кристиан Шрёттер"
+msgid "Christian Schrötter"
+msgstr "Кристиан Шрёттер"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Испанский:"
+msgid "Spanish:"
+msgstr "Испанский:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Баскский:"
+msgid "Basque:"
+msgstr "Баскский:"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Французский:"
+msgid "French:"
+msgstr "Французский:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Польский:"
+msgid "Polish:"
+msgstr "Польский:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "Испанский:"
+msgid "Swedish:"
+msgstr "Испанский:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Русский:"
+msgid "Russian:"
+msgstr "Русский:"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Бенгальский:"
+msgid "Bengali:"
+msgstr "Бенгальский:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Китайский:"
+msgid "Chinese:"
+msgstr "Китайский:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Монтаж видео"
+msgid "Video Editing"
+msgstr "Монтаж видео"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Особая благодарность"
+msgid "Special Thanks"
+msgstr "Особая благодарность"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Итан Чапман"
+msgid "Ethan Chapman"
+msgstr "Итан Чапман"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Тем, кто сообщает об ошибках"
+msgid "All bug reporters"
+msgstr "Тем, кто сообщает об ошибках"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Тем, кто поддерживает на Patreon, Ko-fi и Paypal"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Тем, кто поддерживает на Patreon, Ko-fi и Paypal"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Создано с"
+msgid "Made with"
+msgstr "Создано с"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "Библиотека GDX"
+msgid "LibGDX"
+msgstr "Библиотека GDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "Порт SFXR на Qt"
+msgid "SFXR Qt"
+msgstr "Порт SFXR на Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Студия Android"
+msgid "Android Studio"
+msgstr "Студия Android"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Настройки, влияющие на игровой процесс были изменены, прогресс не будет сохранён"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Настройки, влияющие на игровой процесс были изменены, прогресс не будет "
+"сохранён"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "НАЧАТЬ ЗАНОВО"
+msgid "RESTART"
+msgstr "НАЧАТЬ ЗАНОВО"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "НАЗАД В МЕНЮ"
+msgid "BACK TO MENU"
+msgstr "НАЗАД В МЕНЮ"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "ПРОДОЛЖИТЬ"
+msgid "CONTINUE"
+msgstr "ПРОДОЛЖИТЬ"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Конфигурация геймпада"
+msgid "Gamepad config"
+msgstr "Конфигурация геймпада"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Триггер:"
+msgid "Trigger:"
+msgstr "Триггер:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Назад/разворот:"
+msgid "Back/reverse:"
+msgstr "Назад/разворот:"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Конфигурация клавиатуры"
+msgid "Keyboard config"
+msgstr "Конфигурация клавиатуры"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "ОДИН ИГРОК"
+msgid "ONE PLAYER"
+msgstr "ОДИН ИГРОК"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "НЕСКОЛЬКО ИГРОКОВ"
+msgid "MULTI PLAYER"
+msgstr "НЕСКОЛЬКО ИГРОКОВ"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "ОБЫЧНАЯ ГОНКА"
+msgid "QUICK RACE"
+msgstr "ОБЫЧНАЯ ГОНКА"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "ЧЕМПИОНАТ"
+msgid "CHAMPIONSHIP"
+msgstr "ЧЕМПИОНАТ"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "НАСТРОЙКИ"
+msgid "SETTINGS"
+msgstr "НАСТРОЙКИ"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "ВЫЙТИ"
+msgid "QUIT"
+msgstr "ВЫЙТИ"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid   "Select Your Vehicles"
-msgstr  "Выберите ваши автомобили"
+msgid "Select Your Vehicles"
+msgstr "Выберите ваши автомобили"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Приготовиться!"
+msgid "Ready!"
+msgstr "Приготовиться!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Не все геймпады подключены"
+msgid "Some gamepads are missing"
+msgstr "Не все геймпады подключены"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Пауза"
+msgid "Paused"
+msgstr "Пауза"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "ПРОДОЛЖИТЬ"
+msgid "RESUME"
+msgstr "ПРОДОЛЖИТЬ"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "ВЫЙТИ В МЕНЮ"
+msgid "QUIT TO MENU"
+msgstr "ВЫЙТИ В МЕНЮ"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Выберите чемпионат"
+msgid "Select Championship"
+msgstr "Выберите чемпионат"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Выберите режим игры"
+msgid "Select Game Mode"
+msgstr "Выберите режим игры"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid   "Select Language"
-msgstr  "Выберите язык"
+msgid "Select Language"
+msgstr "Выберите язык"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Выберите гоночную трассу"
+msgid "Select Track"
+msgstr "Выберите гоночную трассу"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Лучший круг"
+msgid "Best Lap"
+msgstr "Лучший круг"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Лучшее общее время"
+msgid "Best Total"
+msgstr "Лучшее общее время"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Выберите ваш транспорт"
+msgid "Select Your Vehicle"
+msgstr "Выберите ваш транспорт"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "2-лошади"
+msgid "2-Deuch"
+msgstr "2-лошади"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ант Он-1"
+msgid "Ant On-1"
+msgstr "Ант Он-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "Тёмный М"
+msgid "Dark M"
+msgstr "Тёмный М"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Комбайн"
+msgid "Harvester"
+msgstr "Комбайн"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Джип"
+msgid "Jeep"
+msgstr "Джип"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Мирамар"
+msgid "Miramar"
+msgstr "Мирамар"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Пикап"
+msgid "Pickup"
+msgstr "Пикап"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Дорожный патруль"
+msgid "Highway Patrol"
+msgstr "Дорожный патруль"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Красная молния"
+msgid "Red Lightning"
+msgstr "Красная молния"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Родстер"
+msgid "Roadster"
+msgstr "Родстер"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Ракета"
+msgid "Rocket"
+msgstr "Ракета"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Трак Санты"
+msgid "Santa Truck"
+msgstr "Трак Санты"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Поделиться через"
+msgid "Share via"
+msgstr "Поделиться через"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Нашли ошибку? Нажмите на эту кнопку, чтобы сообщить о ней."
+msgid "Hit a bug? Use this button to report it."
+msgstr "Нашли ошибку? Нажмите на эту кнопку, чтобы сообщить о ней."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "СООБЩИТЬ ОБ ОШИБКЕ"
+msgid "REPORT BUG"
+msgstr "СООБЩИТЬ ОБ ОШИБКЕ"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Взорви %# машину ракетой"
-msgstr[1]       "Взорви %# машины ракетой"
-msgstr[2]       "Взорви %# машин ракетой"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Взорви %# машину ракетой"
+msgstr[1] "Взорви %# машины ракетой"
+msgstr[2] "Взорви %# машин ракетой"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Покинь дорогу %# раз"
-msgstr[1]       "Покинь дорогу %# раза"
-msgstr[2]       "Покинь дорогу %# раз"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Покинь дорогу %# раз"
+msgstr[1] "Покинь дорогу %# раза"
+msgstr[2] "Покинь дорогу %# раз"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Подбери %# бонус"
-msgstr[1]       "Подбери %# бонуса"
-msgstr[2]       "Подбери %# бонусов"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Подбери %# бонус"
+msgstr[1] "Подбери %# бонуса"
+msgstr[2] "Подбери %# бонусов"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Геймпад"
+msgid "Gamepad"
+msgstr "Геймпад"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Клавиатура"
+msgid "Keyboard"
+msgstr "Клавиатура"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Кнопки-пирожные"
+msgid "Pie buttons"
+msgstr "Кнопки-пирожные"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Боковые кнопки"
+msgid "Side buttons"
+msgstr "Боковые кнопки"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Рейтинг чемпионата"
+msgid "Championship Rankings"
+msgstr "Рейтинг чемпионата"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Результаты гонки"
+msgid "Race Results"
+msgstr "Результаты гонки"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "Поздравляю, отличная гонка!"
+msgid "Congratulations, great race!"
+msgstr "Поздравляю, отличная гонка!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "У тебя есть серьёзные навыки вождения!"
+msgid "You've got some serious driving skills!"
+msgstr "У тебя есть серьёзные навыки вождения!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "Ты - чемпион!"
+msgid "You're a champ!"
+msgstr "Ты - чемпион!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "Мне нравится такое исполнение!"
+msgid "Congrats for this performance!"
+msgstr "Мне нравится такое исполнение!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "Восхитительно!"
+msgid "Impressive!"
+msgstr "Восхитительно!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "N°"
+msgid "#"
+msgstr "N°"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Лучший круг"
+msgid "Best lap"
+msgstr "Лучший круг"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Гонщик"
+msgid "Racer"
+msgstr "Гонщик"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Общее время"
+msgid "Total time"
+msgstr "Общее время"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Очки"
+msgid "Points"
+msgstr "Очки"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Время гонки"
+msgid "Race time"
+msgstr "Время гонки"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Приди к финишу третьим или ещё быстрее на чемпионате %s"
+msgid "Finish third or better at %s championship"
+msgstr "Приди к финишу третьим или ещё быстрее на чемпионате %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Приди к финишу вторым или ещё быстрее на чемпионате %s"
+msgid "Finish second or better at %s championship"
+msgstr "Приди к финишу вторым или ещё быстрее на чемпионате %s"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Приди к финишу первым на чемпионате %s"
+msgid "Finish first at %s championship"
+msgstr "Приди к финишу первым на чемпионате %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "Чемпионат\n"
-        "окончен!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"Чемпионат\n"
+"окончен!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "Об игре"
+msgid "About"
+msgstr "Об игре"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "ТИТРЫ"
+msgid "CREDITS"
+msgstr "ТИТРЫ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels бесплатна, но вы можете поддержать её\n"
-        "разработку любым удобным способом."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels бесплатна, но вы можете поддержать её\n"
+"разработку любым удобным способом."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "ПОДДЕРЖАТЬ ИГРУ"
+msgid "VISIT SUPPORT PAGE"
+msgstr "ПОДДЕРЖАТЬ ИГРУ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Узнать больше о Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "Узнать больше о Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "ПОСЕТИТЬ САЙТ ИГРЫ"
+msgid "VISIT WEB SITE"
+msgstr "ПОСЕТИТЬ САЙТ ИГРЫ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Под капотом"
+msgid "Under the hood"
+msgstr "Под капотом"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Эти опции нужны для разработки Pixel Wheels, но и вы можете свободно менять их!"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Эти опции нужны для разработки Pixel Wheels, но и вы можете свободно менять "
+"их!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "ДЛЯ РАЗРАБОТЧИКОВ"
+msgid "DEV. OPTIONS"
+msgstr "ДЛЯ РАЗРАБОТЧИКОВ"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Управление"
+msgid "Controls"
+msgstr "Управление"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Игрок #%d:"
+msgid "Player #%d:"
+msgstr "Игрок #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Управление:"
+msgid "Controls:"
+msgstr "Управление:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Основное"
+msgid "General"
+msgstr "Основное"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Язык:"
+msgid "Language:"
+msgstr "Язык:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Звуки"
+msgid "Audio"
+msgstr "Звуки"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Звуки:"
+msgid "Sound FX:"
+msgstr "Звуки:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Музыка:"
+msgid "Music:"
+msgstr "Музыка:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Видео"
+msgid "Video"
+msgstr "Видео"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "На весь экран:"
+msgid "Fullscreen:"
+msgstr "На весь экран:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "НАСТРОИТЬ"
+msgid "CONFIGURE"
+msgstr "НАСТРОИТЬ"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Спасибо за игру!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Зажмите нужную кнопку геймпада..."
+msgid "Thank you for playing!"
+msgstr "Спасибо за игру!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Тормоз"
+msgid "Brake"
+msgstr "Тормоз"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Руль влево"
+msgid "Steer left"
+msgstr "Руль влево"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Руль вправо"
+msgid "Steer right"
+msgstr "Руль вправо"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Триггер"
+msgid "Trigger"
+msgstr "Триггер"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Вверх"
+msgid "Up"
+msgstr "Вверх"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Вниз"
+msgid "Down"
+msgstr "Вниз"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Влево"
+msgid "Left"
+msgstr "Влево"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Вправо"
+msgid "Right"
+msgstr "Вправо"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Активировать"
+msgid "Activate"
+msgstr "Активировать"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Назад"
+msgid "Back"
+msgstr "Назад"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Отсутствует"
+msgid "Missing"
+msgstr "Отсутствует"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "ОК"
+msgid "OK"
+msgstr "ОК"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Игрок #%d: %s"
+msgid "Player #%d: %s"
+msgstr "Игрок #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "ГЛАВНОЕ МЕНЮ"
+msgid "MAIN MENU"
+msgstr "ГЛАВНОЕ МЕНЮ"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Заблокировано]"
+msgid "[Locked]"
+msgstr "[Заблокировано]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "Компьютер"
+msgid "CPU"
+msgstr "Компьютер"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "Разблокирован новый транспорт!"
+msgid "New vehicle unlocked!"
+msgstr "Разблокирован новый транспорт!"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "Разблокирован новый чемпионат!"
+msgid "New championship unlocked!"
+msgstr "Разблокирован новый чемпионат!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1ый"
+msgid "1st"
+msgstr "1ый"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2ой"
+msgid "2nd"
+msgstr "2ой"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3ий"
+msgid "3rd"
+msgstr "3ий"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4ый"
+msgid "4th"
+msgstr "4ый"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5ый"
+msgid "5th"
+msgstr "5ый"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6ой"
+msgid "6th"
+msgstr "6ой"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Хотите заполнить сообщение об ошибке? Нажмите на эту кнопку, чтобы найти и прикрепить файл лога."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Хотите заполнить сообщение об ошибке? Нажмите на эту кнопку, чтобы найти и "
+"прикрепить файл лога."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "НАЙТИ ФАЙЛ ЛОГА"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "НАЙТИ ФАЙЛ ЛОГА"
+
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Зажмите нужную кнопку геймпада..."

--- a/android/assets/po/sv.po
+++ b/android/assets/po/sv.po
@@ -3,848 +3,860 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: \n"
-        "PO-Revision-Date: 2022-07-09 16:34+0200\n"
-        "Last-Translator: \n"
-        "Language-Team: \n"
-        "Language: sv\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-        "X-Generator: Poedit 2.3\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2022-07-09 16:34+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #: android/assets/championships/0.xml:2
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "Lantliv"
+msgid "Country Life"
+msgstr "Lantliv"
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  "Välkommen!"
+msgid "Welcome!"
+msgstr "Välkommen!"
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  "Flod"
+msgid "River"
+msgstr "Flod"
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  "Översvämning"
+msgid "Flood"
+msgstr "Översvämning"
 
 #: android/assets/championships/1.xml:2
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "Square Mountains"
+msgid "Square Mountains"
+msgstr "Square Mountains"
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  "Let it snow"
+msgid "Let it snow"
+msgstr "Let it snow"
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  "Halka inte!"
+msgid "Don't slip!"
+msgstr "Halka inte!"
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  "Pix Cities"
+msgid "Pix Cities"
+msgstr "Pix Cities"
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  "Blocky Town"
+msgid "Blocky Town"
+msgstr "Blocky Town"
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  "Tiny sur Mer"
+msgid "Tiny sur Mer"
+msgstr "Tiny sur Mer"
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "Ett rallyspel baserat på öppen källkod"
+msgid "An open-source racing game"
+msgstr "Ett rallyspel baserat på öppen källkod"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "Kod"
+msgid "Code"
+msgstr "Kod"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "Pixlar"
+msgid "Pixels"
+msgstr "Pixlar"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "Musik"
+msgid "Music"
+msgstr "Musik"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "Meny:"
+msgid "Menu:"
+msgstr "Meny:"
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "Seger:"
+msgid "Victory:"
+msgstr "Seger:"
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "Mästerskap Lantliv:"
+msgid "Country Life championship:"
+msgstr "Mästerskap Lantliv:"
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "Mästerskap Square Mountains:"
+msgid "Square Mountains championship:"
+msgstr "Mästerskap Square Mountains:"
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "Mästerskap Pix Cities:"
+msgid "Pix Cities championship:"
+msgstr "Mästerskap Pix Cities:"
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "Ljudeffekter"
+msgid "Sound Effects"
+msgstr "Ljudeffekter"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "Andra ljudeffekter"
+msgid "Other sound effects"
+msgstr "Andra ljudeffekter"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "Typsnitt"
+msgid "Fonts"
+msgstr "Typsnitt"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "Översättningar"
+msgid "Translations"
+msgstr "Översättningar"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  "Tyska:"
+msgid "German:"
+msgstr "Tyska:"
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  "Christian Schrötter"
+msgid "Christian Schrötter"
+msgstr "Christian Schrötter"
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "Spanska:"
+msgid "Spanish:"
+msgstr "Spanska:"
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  "Baskiska:"
+msgid "Basque:"
+msgstr "Baskiska:"
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  "Josu Igoa"
+msgid "Josu Igoa"
+msgstr "Josu Igoa"
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "Franska:"
+msgid "French:"
+msgstr "Franska:"
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "Polska:"
+msgid "Polish:"
+msgstr "Polska:"
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
-msgid   "Swedish:"
-msgstr  "Svenska:"
+msgid "Swedish:"
+msgstr "Svenska:"
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  "Sanchez"
+msgid "Sanchez"
+msgstr "Sanchez"
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  "Ryska:"
+msgid "Russian:"
+msgstr "Ryska:"
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  "Nickoriginal"
+msgid "Nickoriginal"
+msgstr "Nickoriginal"
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "Bengaliska:"
+msgid "Bengali:"
+msgstr "Bengaliska:"
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "Kinesiska:"
+msgid "Chinese:"
+msgstr "Kinesiska:"
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "Videoredigering"
+msgid "Video Editing"
+msgstr "Videoredigering"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "Extra tack till"
+msgid "Special Thanks"
+msgstr "Extra tack till"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "Alla felrapporterare"
+msgid "All bug reporters"
+msgstr "Alla felrapporterare"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Alla som stöttar på Patreon, Ko-fi och Paypal"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Alla som stöttar på Patreon, Ko-fi och Paypal"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "Gjort med"
+msgid "Made with"
+msgstr "Gjort med"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "Inställningar som påverkar spelsession har modifierats, poäng kommer inte att sparas"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr ""
+"Inställningar som påverkar spelsession har modifierats, poäng kommer inte "
+"att sparas"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "STARTA OM"
+msgid "RESTART"
+msgstr "STARTA OM"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "ÅTERGÅ TILL MENY"
+msgid "BACK TO MENU"
+msgstr "ÅTERGÅ TILL MENY"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "FORTSÄTT"
+msgid "CONTINUE"
+msgstr "FORTSÄTT"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "Spelkontrollkonfiguration"
+msgid "Gamepad config"
+msgstr "Spelkontrollkonfiguration"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "Utlösare:"
+msgid "Trigger:"
+msgstr "Utlösare:"
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "Bakåt/backa:"
+msgid "Back/reverse:"
+msgstr "Bakåt/backa:"
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "Tangentbordskonfiguration"
+msgid "Keyboard config"
+msgstr "Tangentbordskonfiguration"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "ENSPELARLÄGE"
+msgid "ONE PLAYER"
+msgstr "ENSPELARLÄGE"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "FLERSPELARLÄGE"
+msgid "MULTI PLAYER"
+msgstr "FLERSPELARLÄGE"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "SNABBTÄVLING"
+msgid "QUICK RACE"
+msgstr "SNABBTÄVLING"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "MÄSTERSKAP"
+msgid "CHAMPIONSHIP"
+msgstr "MÄSTERSKAP"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "INSTÄLLNINGAR"
+msgid "SETTINGS"
+msgstr "INSTÄLLNINGAR"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "AVSLUTA"
+msgid "QUIT"
+msgstr "AVSLUTA"
 
 #: android/assets/screens/multiplayer.gdxui:10
-msgid   "Select Your Vehicles"
-msgstr  "Markera dina fordon"
+msgid "Select Your Vehicles"
+msgstr "Markera dina fordon"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "Klara!"
+msgid "Ready!"
+msgstr "Klara!"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "Några spelkontroller saknas"
+msgid "Some gamepads are missing"
+msgstr "Några spelkontroller saknas"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "Pausat"
+msgid "Paused"
+msgstr "Pausat"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "ÅTERGÅ TILL SPEL"
+msgid "RESUME"
+msgstr "ÅTERGÅ TILL SPEL"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "TILLBAKA TILL MENY"
+msgid "QUIT TO MENU"
+msgstr "TILLBAKA TILL MENY"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "Markera tävling"
+msgid "Select Championship"
+msgstr "Markera tävling"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "Markera spelläge"
+msgid "Select Game Mode"
+msgstr "Markera spelläge"
 
 #: android/assets/screens/selectlanguage.gdxui:5
-msgid   "Select Language"
-msgstr  "Markera språk"
+msgid "Select Language"
+msgstr "Markera språk"
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "Markera lopp"
+msgid "Select Track"
+msgstr "Markera lopp"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "Bästa varv"
+msgid "Best Lap"
+msgstr "Bästa varv"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "Totalbästa"
+msgid "Best Total"
+msgstr "Totalbästa"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "Markera ditt fordon"
+msgid "Select Your Vehicle"
+msgstr "Markera ditt fordon"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  "2-Deuch"
+msgid "2-Deuch"
+msgstr "2-Deuch"
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  "Ant On-1"
+msgid "Ant On-1"
+msgstr "Ant On-1"
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  "Dark M"
+msgid "Dark M"
+msgstr "Dark M"
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  "Harvester"
+msgid "Harvester"
+msgstr "Harvester"
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  "Jeep"
+msgid "Jeep"
+msgstr "Jeep"
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  "Miramar"
+msgid "Miramar"
+msgstr "Miramar"
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  "Pickup"
+msgid "Pickup"
+msgstr "Pickup"
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  "Highway Patrol"
+msgid "Highway Patrol"
+msgstr "Highway Patrol"
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  "Red Lightning"
+msgid "Red Lightning"
+msgstr "Red Lightning"
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  "Roadster"
+msgid "Roadster"
+msgstr "Roadster"
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  "Rocket"
+msgid "Rocket"
+msgstr "Rocket"
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  "Santa Truck"
+msgid "Santa Truck"
+msgstr "Santa Truck"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "Dela via"
+msgid "Share via"
+msgstr "Dela via"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "Hittat ett fel? Använd denna knapp för att rapportera det."
+msgid "Hit a bug? Use this button to report it."
+msgstr "Hittat ett fel? Använd denna knapp för att rapportera det."
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "RAPPORTERA FEL"
+msgid "REPORT BUG"
+msgstr "RAPPORTERA FEL"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "Träffa ett fordon med en missil"
-msgstr[1]       "Träffa fordon med en missil"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "Träffa ett fordon med en missil"
+msgstr[1] "Träffa fordon med en missil"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "Lämna väg en gång"
-msgstr[1]       "Lämna väg %# gånger"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "Lämna väg en gång"
+msgstr[1] "Lämna väg %# gånger"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "Välj en bonus"
-msgstr[1]       "Välj %# bonusar"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "Välj en bonus"
+msgstr[1] "Välj %# bonusar"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "Spelkontroll"
+msgid "Gamepad"
+msgstr "Spelkontroll"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "Tangentbord"
+msgid "Keyboard"
+msgstr "Tangentbord"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "Pajknappar"
+msgid "Pie buttons"
+msgstr "Pajknappar"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "Sidoknappar"
+msgid "Side buttons"
+msgstr "Sidoknappar"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "Mästerskapsranking"
+msgid "Championship Rankings"
+msgstr "Mästerskapsranking"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "Tävlingsresultat"
+msgid "Race Results"
+msgstr "Tävlingsresultat"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "Gratulerar, utmärkt kört!"
+msgid "Congratulations, great race!"
+msgstr "Gratulerar, utmärkt kört!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "Du är riktigt duktig på att köra!"
+msgid "You've got some serious driving skills!"
+msgstr "Du är riktigt duktig på att köra!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "Du är en mästare!"
+msgid "You're a champ!"
+msgstr "Du är en mästare!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "Grattis till denna prestation!"
+msgid "Congrats for this performance!"
+msgstr "Grattis till denna prestation!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "Imponerande!"
+msgid "Impressive!"
+msgstr "Imponerande!"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "#"
+msgid "#"
+msgstr "#"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "Bästa varv"
+msgid "Best lap"
+msgstr "Bästa varv"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "Rallyförare"
+msgid "Racer"
+msgstr "Rallyförare"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "Total tid"
+msgid "Total time"
+msgstr "Total tid"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "Poäng"
+msgid "Points"
+msgstr "Poäng"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "Tävlingstid"
+msgid "Race time"
+msgstr "Tävlingstid"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "Avsluta på tredje plats eller bättre i %s mästerskap"
+msgid "Finish third or better at %s championship"
+msgstr "Avsluta på tredje plats eller bättre i %s mästerskap"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "Avsluta på andra plats eller bättre i %s mästerskap"
+msgid "Finish second or better at %s championship"
+msgstr "Avsluta på andra plats eller bättre i %s mästerskap"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "Avsluta på första plats i %s mästerskap"
+msgid "Finish first at %s championship"
+msgstr "Avsluta på första plats i %s mästerskap"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "[Måste separeras med två meningar med en ny rad] Mäskerskap avslutat!"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr "[Måste separeras med två meningar med en ny rad] Mäskerskap avslutat!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "Om"
+msgid "About"
+msgstr "Om"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "Tack till"
+msgid "CREDITS"
+msgstr "Tack till"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels är gratis, men du kan stötta dess\n"
-        "utveckling på olika sätt."
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels är gratis, men du kan stötta dess\n"
+"utveckling på olika sätt."
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "BESÖK STÖDWEBBSIDA"
+msgid "VISIT SUPPORT PAGE"
+msgstr "BESÖK STÖDWEBBSIDA"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "Lär dig mer om Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "Lär dig mer om Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "Besök webbplats"
+msgid "VISIT WEB SITE"
+msgstr "Besök webbplats"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "Under huven"
+msgid "Under the hood"
+msgstr "Under huven"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "Dessa alternativ är mest intressanta för att utveckla Pixel Wheels, men ta gärna en titt på dem!"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr ""
+"Dessa alternativ är mest intressanta för att utveckla Pixel Wheels, men ta "
+"gärna en titt på dem!"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "UTV.ALTERNATIV"
+msgid "DEV. OPTIONS"
+msgstr "UTV.ALTERNATIV"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "Kontroller"
+msgid "Controls"
+msgstr "Kontroller"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "Spelare #%d:"
+msgid "Player #%d:"
+msgstr "Spelare #%d:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "Kontroller:"
+msgid "Controls:"
+msgstr "Kontroller:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "Allmänt"
+msgid "General"
+msgstr "Allmänt"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "Språk:"
+msgid "Language:"
+msgstr "Språk:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "Ljud"
+msgid "Audio"
+msgstr "Ljud"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "Ljudeffekter:"
+msgid "Sound FX:"
+msgstr "Ljudeffekter:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "Musik:"
+msgid "Music:"
+msgstr "Musik:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "Video"
+msgid "Video"
+msgstr "Video"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "Helskärm:"
+msgid "Fullscreen:"
+msgstr "Helskärm:"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "KONFIGURERA"
+msgid "CONFIGURE"
+msgstr "KONFIGURERA"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "Tack för att du spelade!"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  "Tryck på spelkontrollsknappen..."
+msgid "Thank you for playing!"
+msgstr "Tack för att du spelade!"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "Broms"
+msgid "Brake"
+msgstr "Broms"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "Sväng vänster"
+msgid "Steer left"
+msgstr "Sväng vänster"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "Sväng höger"
+msgid "Steer right"
+msgstr "Sväng höger"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "Utlösare"
+msgid "Trigger"
+msgstr "Utlösare"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "Upp"
+msgid "Up"
+msgstr "Upp"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "Ner"
+msgid "Down"
+msgstr "Ner"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "Vänster"
+msgid "Left"
+msgstr "Vänster"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "Höger"
+msgid "Right"
+msgstr "Höger"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "Aktivera"
+msgid "Activate"
+msgstr "Aktivera"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "Tillbaka"
+msgid "Back"
+msgstr "Tillbaka"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "Saknas"
+msgid "Missing"
+msgstr "Saknas"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "Ok"
+msgid "OK"
+msgstr "Ok"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "Spelare #%d: %s"
+msgid "Player #%d: %s"
+msgstr "Spelare #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "HUVUDMENY"
+msgid "MAIN MENU"
+msgstr "HUVUDMENY"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[Låst]"
+msgid "[Locked]"
+msgstr "[Låst]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  "CPU"
+msgid "CPU"
+msgstr "CPU"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  "Nytt fordon upplåst!"
+msgid "New vehicle unlocked!"
+msgstr "Nytt fordon upplåst!"
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
-msgid   "New championship unlocked!"
-msgstr  "Nytt mästerskap upplåst!"
+msgid "New championship unlocked!"
+msgstr "Nytt mästerskap upplåst!"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "1a"
+msgid "1st"
+msgstr "1a"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "2a"
+msgid "2nd"
+msgstr "2a"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "3e"
+msgid "3rd"
+msgstr "3e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "4e"
+msgid "4th"
+msgstr "4e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "5e"
+msgid "5th"
+msgstr "5e"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "6e"
+msgid "6th"
+msgstr "6e"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "Behöver du skicka en felrapportering? Använd denna knapp för att hitta loggfilen att bifoga."
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr ""
+"Behöver du skicka en felrapportering? Använd denna knapp för att hitta "
+"loggfilen att bifoga."
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "ÖPPNA MAPP FÖR LOGGFIL"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "ÖPPNA MAPP FÖR LOGGFIL"
 
-#~ msgid        "Svenska:"
-#~ msgstr       "Swedish:"
+#~ msgid "Press the gamepad key..."
+#~ msgstr "Tryck på spelkontrollsknappen..."
+
+#~ msgid "Svenska:"
+#~ msgstr "Swedish:"

--- a/android/assets/po/zh_CN.po
+++ b/android/assets/po/zh_CN.po
@@ -3,876 +3,881 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Lu Xu <oliver_lew@outlook.com>, 2022.
 #
-msgid   ""
-msgstr  "Project-Id-Version: \n"
-        "Report-Msgid-Bugs-To: \n"
-        "PO-Revision-Date: 2022-05-15 12:22+0800\n"
-        "Last-Translator: Lu Xu <oliver_lew@outlook.com>\n"
-        "Language-Team: Chinese\n"
-        "Language: zh_CN\n"
-        "MIME-Version: 1.0\n"
-        "Content-Type: text/plain; charset=UTF-8\n"
-        "Content-Transfer-Encoding: 8bit\n"
-        "Plural-Forms: nplurals=1; plural=0;\n"
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2022-05-15 12:22+0800\n"
+"Last-Translator: Lu Xu <oliver_lew@outlook.com>\n"
+"Language-Team: Chinese\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: android/assets/championships/0.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Country Life"
-msgstr  "乡村生活锦标赛："
+msgid "Country Life"
+msgstr "乡村生活锦标赛："
 
 #: android/assets/championships/0.xml:3
 msgctxt "track"
-msgid   "Welcome!"
-msgstr  ""
+msgid "Welcome!"
+msgstr ""
 
 #: android/assets/championships/0.xml:15
 msgctxt "track"
-msgid   "River"
-msgstr  ""
+msgid "River"
+msgstr ""
 
 #: android/assets/championships/0.xml:27
 msgctxt "track"
-msgid   "Flood"
-msgstr  ""
+msgid "Flood"
+msgstr ""
 
 #: android/assets/championships/1.xml:2
 #, fuzzy
 msgctxt "championship"
-msgid   "Square Mountains"
-msgstr  "方正山脉锦标赛："
+msgid "Square Mountains"
+msgstr "方正山脉锦标赛："
 
 #: android/assets/championships/1.xml:3
 msgctxt "track"
-msgid   "Let it snow"
-msgstr  ""
+msgid "Let it snow"
+msgstr ""
 
 #: android/assets/championships/1.xml:15
 msgctxt "track"
-msgid   "Don't slip!"
-msgstr  ""
+msgid "Don't slip!"
+msgstr ""
 
 #: android/assets/championships/1.xml:27
 msgctxt "track"
-msgid   "Up, up, up... and down!"
-msgstr  ""
+msgid "Up, up, up... and down!"
+msgstr ""
 
 #: android/assets/championships/2.xml:2
 msgctxt "championship"
-msgid   "Pix Cities"
-msgstr  ""
+msgid "Pix Cities"
+msgstr ""
 
 #: android/assets/championships/2.xml:3
 msgctxt "track"
-msgid   "Blocky Town"
-msgstr  ""
+msgid "Blocky Town"
+msgstr ""
 
 #: android/assets/championships/2.xml:15
 msgctxt "track"
-msgid   "Tiny sur Mer"
-msgstr  ""
+msgid "Tiny sur Mer"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:6
-msgid   "Pixel Wheels"
-msgstr  "Pixel Wheels"
+msgid "Pixel Wheels"
+msgstr "Pixel Wheels"
 
 #: android/assets/screens/credits.gdxui:8
-msgid   "An open-source racing game"
-msgstr  "一款开源赛车游戏"
+msgid "An open-source racing game"
+msgstr "一款开源赛车游戏"
 
 #: android/assets/screens/credits.gdxui:10
-msgid   "Code"
-msgstr  "代码"
+msgid "Code"
+msgstr "代码"
 
 #: android/assets/screens/credits.gdxui:12
 #: android/assets/screens/credits.gdxui:16
 #: android/assets/screens/credits.gdxui:50
 #: android/assets/screens/credits.gdxui:75
-msgid   "Aurélien Gâteau"
-msgstr  "Aurélien Gâteau"
+msgid "Aurélien Gâteau"
+msgstr "Aurélien Gâteau"
 
 #: android/assets/screens/credits.gdxui:14
-msgid   "Pixels"
-msgstr  "图像"
+msgid "Pixels"
+msgstr "图像"
 
 #: android/assets/screens/credits.gdxui:17
 #: android/assets/screens/credits.gdxui:98
-msgid   "Antonin Gâteau"
-msgstr  "Antonin Gâteau"
+msgid "Antonin Gâteau"
+msgstr "Antonin Gâteau"
 
 #: android/assets/screens/credits.gdxui:19
-msgid   "Music"
-msgstr  "音乐"
+msgid "Music"
+msgstr "音乐"
 
 #: android/assets/screens/credits.gdxui:21
-msgid   "Menu:"
-msgstr  "菜单："
+msgid "Menu:"
+msgstr "菜单："
 
 #: android/assets/screens/credits.gdxui:22
-msgid   "\"Lightspeed\""
-msgstr  "\"Lightspeed\""
+msgid "\"Lightspeed\""
+msgstr "\"Lightspeed\""
 
 #: android/assets/screens/credits.gdxui:23
-msgid   "Thomas Tripon"
-msgstr  "Thomas Tripon"
+msgid "Thomas Tripon"
+msgstr "Thomas Tripon"
 
 #: android/assets/screens/credits.gdxui:25
-msgid   "Victory:"
-msgstr  "获胜："
+msgid "Victory:"
+msgstr "获胜："
 
 #: android/assets/screens/credits.gdxui:26
-msgid   "\"Core Descent (16-bit) v0.9\""
-msgstr  "\"Core Descent (16-bit) v0.9\""
+msgid "\"Core Descent (16-bit) v0.9\""
+msgstr "\"Core Descent (16-bit) v0.9\""
 
 #: android/assets/screens/credits.gdxui:27
 #: android/assets/screens/credits.gdxui:31
 #: android/assets/screens/credits.gdxui:35
 #: android/assets/screens/credits.gdxui:39
-msgid   "FoxSynergy"
-msgstr  "FoxSynergy"
+msgid "FoxSynergy"
+msgstr "FoxSynergy"
 
 #: android/assets/screens/credits.gdxui:29
-msgid   "Country Life championship:"
-msgstr  "乡村生活锦标赛："
+msgid "Country Life championship:"
+msgstr "乡村生活锦标赛："
 
 #: android/assets/screens/credits.gdxui:30
-msgid   "\"Cosmo Blast v1.0\""
-msgstr  "\"Cosmo Blast v1.0\""
+msgid "\"Cosmo Blast v1.0\""
+msgstr "\"Cosmo Blast v1.0\""
 
 #: android/assets/screens/credits.gdxui:33
-msgid   "Square Mountains championship:"
-msgstr  "方正山脉锦标赛："
+msgid "Square Mountains championship:"
+msgstr "方正山脉锦标赛："
 
 #: android/assets/screens/credits.gdxui:34
-msgid   "\"Lunar Harvest v1.0\""
-msgstr  "\"Lunar Harvest v1.0\""
+msgid "\"Lunar Harvest v1.0\""
+msgstr "\"Lunar Harvest v1.0\""
 
 #: android/assets/screens/credits.gdxui:37
-msgid   "Pix Cities championship:"
-msgstr  "像素城市锦标赛："
+msgid "Pix Cities championship:"
+msgstr "像素城市锦标赛："
 
 #: android/assets/screens/credits.gdxui:38
-msgid   "\"Bouncing Baal v0.95\""
-msgstr  "\"Bouncing Baal v0.95\""
+msgid "\"Bouncing Baal v0.95\""
+msgstr "\"Bouncing Baal v0.95\""
 
 #: android/assets/screens/credits.gdxui:41
-msgid   "Sound Effects"
-msgstr  "音效"
+msgid "Sound Effects"
+msgstr "音效"
 
 #: android/assets/screens/credits.gdxui:43
-msgid   "\"Car tire squeal skid loop\""
-msgstr  "\"Car tire squeal skid loop\""
+msgid "\"Car tire squeal skid loop\""
+msgstr "\"Car tire squeal skid loop\""
 
 #: android/assets/screens/credits.gdxui:44
-msgid   "Tom Haigh"
-msgstr  "Tom Haigh"
+msgid "Tom Haigh"
+msgstr "Tom Haigh"
 
 #: android/assets/screens/credits.gdxui:46
-msgid   "\"Racing car engine sound loops\""
-msgstr  "\"Racing car engine sound loops\""
+msgid "\"Racing car engine sound loops\""
+msgstr "\"Racing car engine sound loops\""
 
 #: android/assets/screens/credits.gdxui:47
-msgid   "domasx2"
-msgstr  "domasx2"
+msgid "domasx2"
+msgstr "domasx2"
 
 #: android/assets/screens/credits.gdxui:49
-msgid   "Other sound effects"
-msgstr  "其它音效"
+msgid "Other sound effects"
+msgstr "其它音效"
 
 #: android/assets/screens/credits.gdxui:52
-msgid   "Fonts"
-msgstr  "字体"
+msgid "Fonts"
+msgstr "字体"
 
 #: android/assets/screens/credits.gdxui:54
-msgid   "Xolonium"
-msgstr  "Xolonium"
+msgid "Xolonium"
+msgstr "Xolonium"
 
 #: android/assets/screens/credits.gdxui:55
-msgid   "Severin Meyer"
-msgstr  "Severin Meyer"
+msgid "Severin Meyer"
+msgstr "Severin Meyer"
 
 #: android/assets/screens/credits.gdxui:57
-msgid   "Kwajong"
-msgstr  "Kwajong"
+msgid "Kwajong"
+msgstr "Kwajong"
 
 #: android/assets/screens/credits.gdxui:58
-msgid   "Tup Wanders"
-msgstr  "Tup Wanders"
+msgid "Tup Wanders"
+msgstr "Tup Wanders"
 
 #: android/assets/screens/credits.gdxui:60
-msgid   "Noto"
-msgstr  "Noto"
+msgid "Noto"
+msgstr "Noto"
 
 #: android/assets/screens/credits.gdxui:61
-msgid   "Google"
-msgstr  "Google"
+msgid "Google"
+msgstr "Google"
 
 #: android/assets/screens/credits.gdxui:63
-msgid   "Translations"
-msgstr  "翻译"
+msgid "Translations"
+msgstr "翻译"
 
 #: android/assets/screens/credits.gdxui:65
-msgid   "German:"
-msgstr  ""
+msgid "German:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:66
-msgid   "Christian Schrötter"
-msgstr  ""
+msgid "Christian Schrötter"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:68
-msgid   "Spanish:"
-msgstr  "西班牙语："
+msgid "Spanish:"
+msgstr "西班牙语："
 
 #: android/assets/screens/credits.gdxui:69
 #: android/assets/screens/credits.gdxui:94
-msgid   "Clara Gâteau"
-msgstr  "Clara Gâteau"
+msgid "Clara Gâteau"
+msgstr "Clara Gâteau"
 
 #: android/assets/screens/credits.gdxui:71
-msgid   "Basque:"
-msgstr  ""
+msgid "Basque:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:72
-msgid   "Josu Igoa"
-msgstr  ""
+msgid "Josu Igoa"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:74
-msgid   "French:"
-msgstr  "法语："
+msgid "French:"
+msgstr "法语："
 
 #: android/assets/screens/credits.gdxui:77
-msgid   "Polish:"
-msgstr  "波兰语："
+msgid "Polish:"
+msgstr "波兰语："
 
 #: android/assets/screens/credits.gdxui:78
-msgid   "PandaCoderPL"
-msgstr  "PandaCoderPL"
+msgid "PandaCoderPL"
+msgstr "PandaCoderPL"
 
 #: android/assets/screens/credits.gdxui:80
 #, fuzzy
-msgid   "Swedish:"
-msgstr  "西班牙语："
+msgid "Swedish:"
+msgstr "西班牙语："
 
 #: android/assets/screens/credits.gdxui:81
-msgid   "Sanchez"
-msgstr  ""
+msgid "Sanchez"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:83
-msgid   "Russian:"
-msgstr  ""
+msgid "Russian:"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:84
-msgid   "Nickoriginal"
-msgstr  ""
+msgid "Nickoriginal"
+msgstr ""
 
 #: android/assets/screens/credits.gdxui:86
-msgid   "Bengali:"
-msgstr  "孟加拉语："
+msgid "Bengali:"
+msgstr "孟加拉语："
 
 #: android/assets/screens/credits.gdxui:87
-msgid   "Oymate"
-msgstr  "Oymate"
+msgid "Oymate"
+msgstr "Oymate"
 
 #: android/assets/screens/credits.gdxui:89
-msgid   "Chinese:"
-msgstr  "简体中文："
+msgid "Chinese:"
+msgstr "简体中文："
 
 #: android/assets/screens/credits.gdxui:90
-msgid   "Lu Xu"
-msgstr  "Lu Xu"
+msgid "Lu Xu"
+msgstr "Lu Xu"
 
 #: android/assets/screens/credits.gdxui:92
-msgid   "Video Editing"
-msgstr  "视频编辑"
+msgid "Video Editing"
+msgstr "视频编辑"
 
 #: android/assets/screens/credits.gdxui:96
-msgid   "Special Thanks"
-msgstr  "特别感谢"
+msgid "Special Thanks"
+msgstr "特别感谢"
 
 #: android/assets/screens/credits.gdxui:99
-msgid   "Guillaume Roche"
-msgstr  "Guillaume Roche"
+msgid "Guillaume Roche"
+msgstr "Guillaume Roche"
 
 #: android/assets/screens/credits.gdxui:100
-msgid   "Ethan Chapman"
-msgstr  "Ethan Chapman"
+msgid "Ethan Chapman"
+msgstr "Ethan Chapman"
 
 #: android/assets/screens/credits.gdxui:101
-msgid   "All bug reporters"
-msgstr  "所有错误报告者"
+msgid "All bug reporters"
+msgstr "所有错误报告者"
 
 #: android/assets/screens/credits.gdxui:102
-msgid   "All supporters on Patreon, Ko-fi and Paypal"
-msgstr  "Patreon, Ko-fi 和 Paypal 平台的所有支持者"
+msgid "All supporters on Patreon, Ko-fi and Paypal"
+msgstr "Patreon, Ko-fi 和 Paypal 平台的所有支持者"
 
 #: android/assets/screens/credits.gdxui:104
-msgid   "Made with"
-msgstr  "开发工具"
+msgid "Made with"
+msgstr "开发工具"
 
 #: android/assets/screens/credits.gdxui:106
-msgid   "LibGDX"
-msgstr  "LibGDX"
+msgid "LibGDX"
+msgstr "LibGDX"
 
 #: android/assets/screens/credits.gdxui:107
-msgid   "Tiled"
-msgstr  "Tiled"
+msgid "Tiled"
+msgstr "Tiled"
 
 #: android/assets/screens/credits.gdxui:108
-msgid   "Aseprite"
-msgstr  "Aseprite"
+msgid "Aseprite"
+msgstr "Aseprite"
 
 #: android/assets/screens/credits.gdxui:109
-msgid   "SFXR Qt"
-msgstr  "SFXR Qt"
+msgid "SFXR Qt"
+msgstr "SFXR Qt"
 
 #: android/assets/screens/credits.gdxui:110
-msgid   "Android Studio"
-msgstr  "Android Studio"
+msgid "Android Studio"
+msgstr "Android Studio"
 
 #: android/assets/screens/debug.gdxui:12
-msgid   "Settings affecting game play have been modified, scores won't be saved"
-msgstr  "影响游戏的设置被修改，分数将不会被保存"
+msgid "Settings affecting game play have been modified, scores won't be saved"
+msgstr "影响游戏的设置被修改，分数将不会被保存"
 
 #: android/assets/screens/finishedoverlay.gdxui:34
 #: android/assets/screens/pauseoverlay.gdxui:9
-msgid   "RESTART"
-msgstr  "重新开始"
+msgid "RESTART"
+msgstr "重新开始"
 
 #: android/assets/screens/finishedoverlay.gdxui:35
-msgid   "BACK TO MENU"
-msgstr  "返回菜单"
+msgid "BACK TO MENU"
+msgstr "返回菜单"
 
 #: android/assets/screens/finishedoverlay.gdxui:38
-msgid   "CONTINUE"
-msgstr  "继续"
+msgid "CONTINUE"
+msgstr "继续"
 
 #: android/assets/screens/gamepadconfig.gdxui:5
-msgid   "Gamepad config"
-msgstr  "游戏手柄配置"
+msgid "Gamepad config"
+msgstr "游戏手柄配置"
 
 #: android/assets/screens/gamepadconfig.gdxui:11
-msgid   "Trigger:"
-msgstr  "触发："
+msgid "Trigger:"
+msgstr "触发："
 
 #: android/assets/screens/gamepadconfig.gdxui:12
-msgid   "Back/reverse:"
-msgstr  "后退/反转："
+msgid "Back/reverse:"
+msgstr "后退/反转："
 
 #: android/assets/screens/keyboardconfig.gdxui:5
-msgid   "Keyboard config"
-msgstr  "键盘配置"
+msgid "Keyboard config"
+msgstr "键盘配置"
 
 #: android/assets/screens/mainmenu.gdxui:26
-msgid   "ONE PLAYER"
-msgstr  "单人模式"
+msgid "ONE PLAYER"
+msgstr "单人模式"
 
 #: android/assets/screens/mainmenu.gdxui:27
-msgid   "MULTI PLAYER"
-msgstr  "多人模式"
+msgid "MULTI PLAYER"
+msgstr "多人模式"
 
 #: android/assets/screens/mainmenu.gdxui:30
 #: android/assets/screens/selectgamemode.gdxui:9
-msgid   "QUICK RACE"
-msgstr  "快速赛"
+msgid "QUICK RACE"
+msgstr "快速赛"
 
 #: android/assets/screens/mainmenu.gdxui:31
 #: android/assets/screens/selectgamemode.gdxui:10
-msgid   "CHAMPIONSHIP"
-msgstr  "锦标赛"
+msgid "CHAMPIONSHIP"
+msgstr "锦标赛"
 
 #: android/assets/screens/mainmenu.gdxui:33
 #: android/assets/screens/pauseoverlay.gdxui:11
-msgid   "SETTINGS"
-msgstr  "设置"
+msgid "SETTINGS"
+msgstr "设置"
 
 #: android/assets/screens/mainmenu.gdxui:35
-msgid   "QUIT"
-msgstr  "退出"
+msgid "QUIT"
+msgstr "退出"
 
 #: android/assets/screens/multiplayer.gdxui:10
 #, fuzzy
-msgid   "Select Your Vehicles"
-msgstr  "选择赛车"
+msgid "Select Your Vehicles"
+msgstr "选择赛车"
 
 #: android/assets/screens/multiplayer.gdxui:16
 #: android/assets/screens/multiplayer.gdxui:18
-msgid   "Ready!"
-msgstr  "准备！"
+msgid "Ready!"
+msgstr "准备！"
 
 #: android/assets/screens/notenoughgamepads.gdxui:4
-msgid   "Some gamepads are missing"
-msgstr  "无游戏手柄"
+msgid "Some gamepads are missing"
+msgstr "无游戏手柄"
 
 #: android/assets/screens/pauseoverlay.gdxui:4
-msgid   "Paused"
-msgstr  "暂停"
+msgid "Paused"
+msgstr "暂停"
 
 #: android/assets/screens/pauseoverlay.gdxui:7
-msgid   "RESUME"
-msgstr  "继续"
+msgid "RESUME"
+msgstr "继续"
 
 #: android/assets/screens/pauseoverlay.gdxui:12
-msgid   "QUIT TO MENU"
-msgstr  "返回菜单"
+msgid "QUIT TO MENU"
+msgstr "返回菜单"
 
 #: android/assets/screens/selectchampionship.gdxui:5
-msgid   "Select Championship"
-msgstr  "选择锦标赛"
+msgid "Select Championship"
+msgstr "选择锦标赛"
 
 #: android/assets/screens/selectgamemode.gdxui:5
-msgid   "Select Game Mode"
-msgstr  "选择游戏模式"
+msgid "Select Game Mode"
+msgstr "选择游戏模式"
 
 #: android/assets/screens/selectlanguage.gdxui:5
 #, fuzzy
-msgid   "Select Language"
-msgstr  "语言："
+msgid "Select Language"
+msgstr "语言："
 
 #: android/assets/screens/selecttrack.gdxui:4
-msgid   "Select Track"
-msgstr  "选择赛道"
+msgid "Select Track"
+msgstr "选择赛道"
 
 #: android/assets/screens/selecttrack.gdxui:11
-msgid   "Best Lap"
-msgstr  "最佳单圈"
+msgid "Best Lap"
+msgstr "最佳单圈"
 
 #: android/assets/screens/selecttrack.gdxui:14
-msgid   "Best Total"
-msgstr  "最佳总用时"
+msgid "Best Total"
+msgstr "最佳总用时"
 
 #: android/assets/screens/selectvehicle.gdxui:10
-msgid   "Select Your Vehicle"
-msgstr  "选择赛车"
+msgid "Select Your Vehicle"
+msgstr "选择赛车"
 
 #: android/assets/vehicles/2cv.xml:1
 msgctxt "vehicle"
-msgid   "2-Deuch"
-msgstr  ""
+msgid "2-Deuch"
+msgstr ""
 
 #: android/assets/vehicles/antonin.xml:1
 msgctxt "vehicle"
-msgid   "Ant On-1"
-msgstr  ""
+msgid "Ant On-1"
+msgstr ""
 
 #: android/assets/vehicles/bigfoot.xml:1
 msgctxt "vehicle"
-msgid   "Broster Truck"
-msgstr  ""
+msgid "Broster Truck"
+msgstr ""
 
 #: android/assets/vehicles/dark-m.xml:1
 msgctxt "vehicle"
-msgid   "Dark M"
-msgstr  ""
+msgid "Dark M"
+msgstr ""
 
 #: android/assets/vehicles/harvester.xml:1
 msgctxt "vehicle"
-msgid   "Harvester"
-msgstr  ""
+msgid "Harvester"
+msgstr ""
 
 #: android/assets/vehicles/jeep.xml:1
 msgctxt "vehicle"
-msgid   "Jeep"
-msgstr  ""
+msgid "Jeep"
+msgstr ""
 
 #: android/assets/vehicles/miramar.xml:1
 msgctxt "vehicle"
-msgid   "Miramar"
-msgstr  ""
+msgid "Miramar"
+msgstr ""
 
 #: android/assets/vehicles/pickup.xml:1
 msgctxt "vehicle"
-msgid   "Pickup"
-msgstr  ""
+msgid "Pickup"
+msgstr ""
 
 #: android/assets/vehicles/police.xml:1
 msgctxt "vehicle"
-msgid   "Highway Patrol"
-msgstr  ""
+msgid "Highway Patrol"
+msgstr ""
 
 #: android/assets/vehicles/red.xml:1
 msgctxt "vehicle"
-msgid   "Red Lightning"
-msgstr  ""
+msgid "Red Lightning"
+msgstr ""
 
 #: android/assets/vehicles/roadster.xml:1
 msgctxt "vehicle"
-msgid   "Roadster"
-msgstr  ""
+msgid "Roadster"
+msgstr ""
 
 #: android/assets/vehicles/rocket.xml:1
 msgctxt "vehicle"
-msgid   "Rocket"
-msgstr  ""
+msgid "Rocket"
+msgstr ""
 
 #: android/assets/vehicles/santa.xml:1
 msgctxt "vehicle"
-msgid   "Santa Truck"
-msgstr  ""
+msgid "Santa Truck"
+msgstr ""
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:58
-msgid   "Share via"
-msgstr  "分享"
+msgid "Share via"
+msgstr "分享"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:63
-msgid   "Hit a bug? Use this button to report it."
-msgstr  "遇到错误？使用这个按钮报告。"
+msgid "Hit a bug? Use this button to report it."
+msgstr "遇到错误？使用这个按钮报告。"
 
 #: android/src/main/com/agateau/pixelwheels/android/AndroidLogExporter.java:68
-msgid   "REPORT BUG"
-msgstr  "报告错误"
+msgid "REPORT BUG"
+msgstr "报告错误"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:104
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:128
-msgid   "Hit one vehicle with a missile"
-msgid_plural    "Hit %# vehicles with a missile"
-msgstr[0]       "使用飞弹命中 %# 辆赛车"
+msgid "Hit one vehicle with a missile"
+msgid_plural "Hit %# vehicles with a missile"
+msgstr[0] "使用飞弹命中 %# 辆赛车"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:113
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:137
-msgid   "Leave road one time"
-msgid_plural    "Leave road %# times"
-msgstr[0]       "离开道路 %# 次"
+msgid "Leave road one time"
+msgid_plural "Leave road %# times"
+msgstr[0] "离开道路 %# 次"
 
 #: core/src/com/agateau/pixelwheels/RewardManagerSetup.java:120
-msgid   "Pick one bonus"
-msgid_plural    "Pick %# bonuses"
-msgstr[0]       "捡到 %# 个奖励"
+msgid "Pick one bonus"
+msgid_plural "Pick %# bonuses"
+msgstr[0] "捡到 %# 个奖励"
 
 #: core/src/com/agateau/pixelwheels/gameinput/GamepadInputHandler.java:46
-msgid   "Gamepad"
-msgstr  "手柄"
+msgid "Gamepad"
+msgstr "手柄"
 
 #: core/src/com/agateau/pixelwheels/gameinput/KeyboardInputHandler.java:46
-msgid   "Keyboard"
-msgstr  "键盘"
+msgid "Keyboard"
+msgstr "键盘"
 
 #: core/src/com/agateau/pixelwheels/gameinput/PieTouchInputHandler.java:51
-msgid   "Pie buttons"
-msgstr  "扇形按钮"
+msgid "Pie buttons"
+msgstr "扇形按钮"
 
 #: core/src/com/agateau/pixelwheels/gameinput/SidesTouchInputHandler.java:51
-msgid   "Side buttons"
-msgstr  "两侧按钮"
+msgid "Side buttons"
+msgstr "两侧按钮"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:296
-msgid   "Championship Rankings"
-msgstr  "锦标赛排名"
+msgid "Championship Rankings"
+msgstr "锦标赛排名"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:297
-msgid   "Race Results"
-msgstr  "竞赛结果"
+msgid "Race Results"
+msgstr "竞赛结果"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:327
-msgid   "Congratulations, great race!"
-msgstr  "祝贺，比赛很棒！"
+msgid "Congratulations, great race!"
+msgstr "祝贺，比赛很棒！"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:328
-msgid   "You've got some serious driving skills!"
-msgstr  "你的车技超群！"
+msgid "You've got some serious driving skills!"
+msgstr "你的车技超群！"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:329
-msgid   "You're a champ!"
-msgstr  "你太棒了！"
+msgid "You're a champ!"
+msgstr "你太棒了！"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:330
-msgid   "Congrats for this performance!"
-msgstr  "恭喜，表现很好！"
+msgid "Congrats for this performance!"
+msgstr "恭喜，表现很好！"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:331
-msgid   "Impressive!"
-msgstr  "惊艳！"
+msgid "Impressive!"
+msgstr "惊艳！"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "#"
-msgstr  "#"
+msgid "#"
+msgstr "#"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
-msgid   "Best lap"
-msgstr  "最佳单圈"
+msgid "Best lap"
+msgstr "最佳单圈"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Racer"
-msgstr  "赛车手"
+msgid "Racer"
+msgstr "赛车手"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:415
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Total time"
-msgstr  "总用时"
+msgid "Total time"
+msgstr "总用时"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:419
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:214
-msgid   "Points"
-msgstr  "分数"
+msgid "Points"
+msgstr "分数"
 
 #: core/src/com/agateau/pixelwheels/racescreen/FinishedOverlay.java:422
-msgid   "Race time"
-msgstr  "比赛时间"
+msgid "Race time"
+msgstr "比赛时间"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:48
 #, fuzzy, java-printf-format
-msgid   "Finish third or better at %s championship"
-msgstr  "在 %s 锦标赛取得至少第三名"
+msgid "Finish third or better at %s championship"
+msgstr "在 %s 锦标赛取得至少第三名"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:50
 #, fuzzy, java-printf-format
-msgid   "Finish second or better at %s championship"
-msgstr  "在 %s 锦标赛取得至少第三名"
+msgid "Finish second or better at %s championship"
+msgstr "在 %s 锦标赛取得至少第三名"
 
 #: core/src/com/agateau/pixelwheels/rewards/ChampionshipRankRewardRule.java:53
 #, fuzzy, java-printf-format
-msgid   "Finish first at %s championship"
-msgstr  "在 %s 锦标赛取得至少第三名"
+msgid "Finish first at %s championship"
+msgstr "在 %s 锦标赛取得至少第三名"
 
 #: core/src/com/agateau/pixelwheels/screens/ChampionshipFinishedScreen.java:196
 msgctxt "Must be two sentences separated by a newline"
-msgid   "Championship\n"
-        "Finished!"
-msgstr  "锦标赛\n"
-        "结束！"
+msgid ""
+"Championship\n"
+"Finished!"
+msgstr ""
+"锦标赛\n"
+"结束！"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:117
-msgid   "About"
-msgstr  "关于"
+msgid "About"
+msgstr "关于"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:119
 #, java-printf-format
-msgid   "Pixel Wheels %s"
-msgstr  "Pixel Wheels %s"
+msgid "Pixel Wheels %s"
+msgstr "Pixel Wheels %s"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:120
-msgid   "CREDITS"
-msgstr  "致谢"
+msgid "CREDITS"
+msgstr "致谢"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:157
-msgid   "Pixel Wheels is free, but you can support its\n"
-        "development in various ways."
-msgstr  "Pixel Wheels 是免费的，但有用很多方式\n"
-        "可以支持其开发。"
+msgid ""
+"Pixel Wheels is free, but you can support its\n"
+"development in various ways."
+msgstr ""
+"Pixel Wheels 是免费的，但有用很多方式\n"
+"可以支持其开发。"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:158
-msgid   "VISIT SUPPORT PAGE"
-msgstr  "访问支持页面"
+msgid "VISIT SUPPORT PAGE"
+msgstr "访问支持页面"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:162
-msgid   "Learn more about Pixel Wheels"
-msgstr  "了解更多关于 Pixel Wheels"
+msgid "Learn more about Pixel Wheels"
+msgstr "了解更多关于 Pixel Wheels"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:163
-msgid   "VISIT WEB SITE"
-msgstr  "访问网页"
+msgid "VISIT WEB SITE"
+msgstr "访问网页"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:170
-msgid   "Under the hood"
-msgstr  "底层"
+msgid "Under the hood"
+msgstr "底层"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:190
-msgid   "These options are mostly interesting for Pixel Wheels development, but feel free to poke around!"
-msgstr  "这些选项通常对 Pixel Wheels 的开发有帮助，但也可随意尝试！"
+msgid ""
+"These options are mostly interesting for Pixel Wheels development, but feel "
+"free to poke around!"
+msgstr "这些选项通常对 Pixel Wheels 的开发有帮助，但也可随意尝试！"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:193
-msgid   "DEV. OPTIONS"
-msgstr  "开发选项"
+msgid "DEV. OPTIONS"
+msgstr "开发选项"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:205
-msgid   "Controls"
-msgstr  "控制"
+msgid "Controls"
+msgstr "控制"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:210
 #, java-printf-format
-msgid   "Player #%d:"
-msgstr  "玩家 #%d："
+msgid "Player #%d:"
+msgstr "玩家 #%d："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:213
-msgid   "Controls:"
-msgstr  "控制："
+msgid "Controls:"
+msgstr "控制："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:219
-msgid   "General"
-msgstr  "常规"
+msgid "General"
+msgstr "常规"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:230
-msgid   "Language:"
-msgstr  "语言："
+msgid "Language:"
+msgstr "语言："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:232
-msgid   "Audio"
-msgstr  "声音"
+msgid "Audio"
+msgstr "声音"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:245
-msgid   "Sound FX:"
-msgstr  "音效："
+msgid "Sound FX:"
+msgstr "音效："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:259
-msgid   "Music:"
-msgstr  "音乐："
+msgid "Music:"
+msgstr "音乐："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:262
-msgid   "Video"
-msgstr  "画面"
+msgid "Video"
+msgstr "画面"
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:276
-msgid   "Fullscreen:"
-msgstr  "全屏："
+msgid "Fullscreen:"
+msgstr "全屏："
 
 #: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:365
-msgid   "CONFIGURE"
-msgstr  "配置"
+msgid "CONFIGURE"
+msgstr "配置"
 
 #: core/src/com/agateau/pixelwheels/screens/CreditsScreen.java:79
-msgid   "Thank you for playing!"
-msgstr  "感谢使用！"
-
-#: core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java:74
-msgid   "Press the gamepad key..."
-msgstr  ""
+msgid "Thank you for playing!"
+msgstr "感谢使用！"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:100
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Brake"
-msgstr  "刹车"
+msgid "Brake"
+msgstr "刹车"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:101
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Steer left"
-msgstr  "左转"
+msgid "Steer left"
+msgstr "左转"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:102
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Steer right"
-msgstr  "右转"
+msgid "Steer right"
+msgstr "右转"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:103
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Trigger"
-msgstr  "触发"
+msgid "Trigger"
+msgstr "触发"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:105
-msgid   "Up"
-msgstr  "上"
+msgid "Up"
+msgstr "上"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:106
-msgid   "Down"
-msgstr  "下"
+msgid "Down"
+msgstr "下"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:107
-msgid   "Left"
-msgstr  "左"
+msgid "Left"
+msgstr "左"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:108
-msgid   "Right"
-msgstr  "右"
+msgid "Right"
+msgstr "右"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:109
-msgid   "Activate"
-msgstr  "激活"
+msgid "Activate"
+msgstr "激活"
 
 #: core/src/com/agateau/pixelwheels/screens/KeyboardConfigScreen.java:110
-msgid   "Back"
-msgstr  "后退"
+msgid "Back"
+msgstr "后退"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "Missing"
-msgstr  "缺失"
+msgid "Missing"
+msgstr "缺失"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:57
-msgid   "OK"
-msgstr  "OK"
+msgid "OK"
+msgstr "OK"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:58
 #, java-printf-format
-msgid   "Player #%d: %s"
-msgstr  "玩家 #%d: %s"
+msgid "Player #%d: %s"
+msgstr "玩家 #%d: %s"
 
 #: core/src/com/agateau/pixelwheels/screens/NotEnoughGamepadsScreen.java:76
-msgid   "MAIN MENU"
-msgstr  "主菜单"
+msgid "MAIN MENU"
+msgstr "主菜单"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectChampionshipScreen.java:157
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:220
 #: core/src/com/agateau/pixelwheels/screens/SelectVehicleScreen.java:143
-msgid   "[Locked]"
-msgstr  "[已锁定]"
+msgid "[Locked]"
+msgstr "[已锁定]"
 
 #: core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java:261
 msgctxt "vehicle-record-placeholder"
-msgid   "CPU"
-msgstr  ""
+msgid "CPU"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:111
-msgid   "New vehicle unlocked!"
-msgstr  ""
+msgid "New vehicle unlocked!"
+msgstr ""
 
 #: core/src/com/agateau/pixelwheels/screens/UnlockedRewardScreen.java:120
 #, fuzzy
-msgid   "New championship unlocked!"
-msgstr  "锦标赛\n"
-        "结束！"
+msgid "New championship unlocked!"
+msgstr ""
+"锦标赛\n"
+"结束！"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:46
-msgid   "1st"
-msgstr  "第1名"
+msgid "1st"
+msgstr "第1名"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:48
-msgid   "2nd"
-msgstr  "第2名"
+msgid "2nd"
+msgstr "第2名"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:50
-msgid   "3rd"
-msgstr  "第3名"
+msgid "3rd"
+msgstr "第3名"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:52
-msgid   "4th"
-msgstr  "第4名"
+msgid "4th"
+msgstr "第4名"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:54
-msgid   "5th"
-msgstr  "第5名"
+msgid "5th"
+msgstr "第5名"
 
 #: core/src/com/agateau/pixelwheels/utils/StringUtils.java:56
-msgid   "6th"
-msgstr  "第6名"
+msgid "6th"
+msgstr "第6名"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:44
-msgid   "Need to file a bug report? Use this button to find the log file to attach."
-msgstr  "需要提交错误报告？点击下方按钮找到日志文件。"
+msgid ""
+"Need to file a bug report? Use this button to find the log file to attach."
+msgstr "需要提交错误报告？点击下方按钮找到日志文件。"
 
 #: desktop/src/com/agateau/pixelwheels/desktop/DesktopLogExporter.java:49
-msgid   "OPEN LOG FILE FOLDER"
-msgstr  "打开日志文件夹"
+msgid "OPEN LOG FILE FOLDER"
+msgstr "打开日志文件夹"
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Police"
-#~ msgstr       "波兰语："
+#~ msgctxt "vehicle"
+#~ msgid "Police"
+#~ msgstr "波兰语："
 
 #, fuzzy
-#~ msgctxt      "vehicle"
-#~ msgid        "Red"
-#~ msgstr       "准备！"
+#~ msgctxt "vehicle"
+#~ msgid "Red"
+#~ msgstr "准备！"
 
 #, fuzzy
-#~ msgid        "Down | Brake:"
-#~ msgstr       "刹车："
+#~ msgid "Down | Brake:"
+#~ msgstr "刹车："
 
 #, fuzzy
-#~ msgid        "Left | Steer left:"
-#~ msgstr       "左转："
+#~ msgid "Left | Steer left:"
+#~ msgstr "左转："
 
 #, fuzzy
-#~ msgid        "Right | Steer right:"
-#~ msgstr       "右转："
+#~ msgid "Right | Steer right:"
+#~ msgstr "右转："
 
-#~ msgid        "OFF"
-#~ msgstr       "关"
+#~ msgid "OFF"
+#~ msgstr "关"
 
-#~ msgid        "ON"
-#~ msgstr       "开"
+#~ msgid "ON"
+#~ msgstr "开"

--- a/core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/GamepadConfigScreen.java
@@ -18,8 +18,6 @@
  */
 package com.agateau.pixelwheels.screens;
 
-import static com.agateau.translations.Translator.tr;
-
 import com.agateau.pixelwheels.GameConfig;
 import com.agateau.pixelwheels.PwGame;
 import com.agateau.pixelwheels.PwRefreshHelper;
@@ -71,7 +69,7 @@ public class GamepadConfigScreen extends PwStageScreen {
         private void updateText() {
             String text;
             if (mEditing) {
-                text = tr("Press the gamepad key...");
+                text = "...";
             } else {
                 text =
                         String.format(


### PR DESCRIPTION
Just remove it: there is no such text in the equivalent keyboard config
screen.

Fixes #224
