### PR TITLE
Update dependencies

### DIFF
--- a/.changes/unreleased/Developers-20221026-084652.yaml
+++ b/.changes/unreleased/Developers-20221026-084652.yaml
@@ -1,0 +1,4 @@
+kind: Developers
+body: Updated Android SDK to 31, Android Gradle Plugin to 7.2.2, Gradle to 7.3.3 and
+  JDK to 11 (#275).
+time: 2022-10-26T08:46:52.856709294+02:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         git \
         imagemagick \
         make \
-        openjdk-8-jdk \
+        openjdk-11-jdk \
         python3-pip \
         python3-setuptools \
         unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Stick to Debian 9 to match F-Droid build infrastructure
-FROM debian:9
+FROM debian:11
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -19,7 +19,8 @@
             android:name="com.agateau.pixelwheels.android.AndroidLauncher"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,12 +31,13 @@ android {
     Properties versionProps = new Properties()
     versionProps.load(new FileInputStream(file('../version.properties')))
 
-    buildToolsVersion "30.0.3"
-    compileSdkVersion 30
+    // Must match ci/install-android-sdk
+    buildToolsVersion "31.0.0"
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.agateau.tinywheels.android"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode versionProps['VERSION_CODE'].toInteger()
         versionName versionProps['VERSION']
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: "android"
+apply plugin: "com.android.application"
 
 configurations { natives }
 
@@ -90,7 +90,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
-        exclude "LICENSE.txt"
+        resources {
+            excludes += ['LICENSE.txt']
+        }
     }
 }
 
@@ -120,6 +122,7 @@ task copyAndroidNatives() {
         }
     }
 }
+
 task run(type: Exec) {
     def path
     def localProperties = project.file("../local.properties")
@@ -141,31 +144,9 @@ task run(type: Exec) {
     def adb = path + "/platform-tools/adb"
     commandLine "$adb", 'shell', 'am', 'start', '-n', 'com.agateau.pixelwheels.android/AndroidLauncher'
 }
-// sets up the Android Idea project, using the old Ant based build.
-idea {
-    module {
-        sourceDirs += file("src")
-        scopes = [COMPILE: [plus: [project.configurations.compile]]]
-
-        iml {
-            withXml {
-                def node = it.asNode()
-                def builder = NodeBuilder.newInstance()
-                builder.current = node
-                builder.component(name: "FacetManager") {
-                    facet(type: "android", name: "Android") {
-                        configuration {
-                            option(name: "UPDATE_PROPERTY_FILES", value: "true")
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
 
 // Thanks to https://gist.github.com/mariotaku/7a0c51955d14def2fa0e#file-signing-gradle-L82
-def decodeKeyStoreFileFromBase64Env(String name) {
+static def decodeKeyStoreFileFromBase64Env(String name) {
     String keyStoreBase64 = System.getenv(name)
     if (keyStoreBase64 == null) {
         return null

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        agp_version = '4.2.2'
+        agp_version = '7.2.2'
     }
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
+    ext {
+        agp_version = '4.2.2'
+    }
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "com.android.tools.build:gradle:$agp_version"
     }
 }
 

--- a/ci/install-android-sdk
+++ b/ci/install-android-sdk
@@ -5,8 +5,8 @@ TOOLS_URL=https://dl.google.com/android/repository/commandlinetools-linux-685806
 
 # Must match android/build.gradle
 PACKAGES="
-build-tools;29.0.3
-platforms;android-29
+build-tools;31.0.0
+platforms;android-31
 "
 
 ANDROID_SDK=/opt/android-sdk

--- a/core-tests/build.gradle
+++ b/core-tests/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
     implementation "junit:junit:4.12"
-    implementation "org.mockito:mockito-core:2.7.22"
+    implementation "org.mockito:mockito-core:3.12.4"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/core/src/com/agateau/pixelwheels/racer/AIPilot.java
+++ b/core/src/com/agateau/pixelwheels/racer/AIPilot.java
@@ -184,10 +184,9 @@ public class AIPilot implements Pilot {
         vehicle.setBraking(false);
 
         // If we are better ranked than a player, slow down a bit
-        float rank = mGameWorld.getRacerRank(mRacer);
         boolean needLimit = false;
-        for (Racer racer : mGameWorld.getPlayerRacers()) {
-            if (mGameWorld.getRacerRank(racer) > rank) {
+        for (Racer playerRacer : mGameWorld.getPlayerRacers()) {
+            if (Racer.compareRaceDistances(mRacer, playerRacer) > 0) {
                 needLimit = true;
                 break;
             }

--- a/core/src/com/agateau/pixelwheels/racer/Racer.java
+++ b/core/src/com/agateau/pixelwheels/racer/Racer.java
@@ -376,4 +376,29 @@ public class Racer extends GameObjectAdapter
     public GameStats getGameStats() {
         return mPilot.getGameStats();
     }
+
+    public static int compareRaceDistances(Racer racer1, Racer racer2) {
+        LapPositionComponent c1 = racer1.getLapPositionComponent();
+        LapPositionComponent c2 = racer2.getLapPositionComponent();
+        if (c1.hasFinishedRace() && c2.hasFinishedRace()) {
+            // If both racers have finished, consider the racer with the shortest total time to be
+            // in front of the other
+            return Float.compare(c2.getTotalTime(), c1.getTotalTime());
+        }
+        if (!c1.hasFinishedRace() && c2.hasFinishedRace()) {
+            return -1;
+        }
+        if (c1.hasFinishedRace() && !c2.hasFinishedRace()) {
+            return 1;
+        }
+        if (c1.getLapCount() < c2.getLapCount()) {
+            return -1;
+        }
+        if (c1.getLapCount() > c2.getLapCount()) {
+            return 1;
+        }
+        float d1 = c1.getLapDistance();
+        float d2 = c2.getLapDistance();
+        return Float.compare(d1, d2);
+    }
 }

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -17,7 +17,6 @@ project.ext.mainClassName = "com.agateau.pixelwheels.desktop.DesktopLauncher"
 project.ext.assetsDir = new File("../android/assets")
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
@@ -33,7 +32,9 @@ task dist(type: Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
+    // Required to fix this error after updating to Gradle 7.3.3:
+    // Entry META-INF/INDEX.LIST is a duplicate but no duplicate handling strategy has been set.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 dist.dependsOn classes
-

--- a/docs/building.md
+++ b/docs/building.md
@@ -29,7 +29,7 @@ java -jar ../../desktop/build/libs/desktop-1.0.jar
 
 Building Pixel Wheels requires the following components:
 
-- A JDK
+- A JDK, version 11
 - libgdx: <https://libgdx.badlogicgames.com>
 - ImageMagick: <http://imagemagick.org>
 - GNU Make: <http://www.gnu.org/software/make/>

--- a/enginelab/build.gradle
+++ b/enginelab/build.gradle
@@ -17,9 +17,24 @@ project.ext.mainClassName = "EngineLab"
 project.ext.assetsDir = new File("../android/assets")
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
 }
+
+task dist(type: Jar) {
+    from files(sourceSets.main.output.classesDirs)
+    from files(sourceSets.main.output.resourcesDir)
+    from {configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }}
+    from files(project.assetsDir)
+
+    manifest {
+        attributes 'Main-Class': project.mainClassName
+    }
+    // Required to fix this error after updating to Gradle 7.3.3:
+    // Entry META-INF/INDEX.LIST is a duplicate but no duplicate handling strategy has been set.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+dist.dependsOn classes

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 17 19:47:47 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 01 08:58:20 CEST 2021
+#Mon Oct 17 19:47:47 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow==7.2.0
+Pillow==9.2.0
 git+https://github.com/agateau/pafx@9c364ca9098d70ee23b6c4caccbcdf0cc44f2fb4#egg=pafx
 pypng==0.0.20

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -20,7 +20,6 @@ project.ext.mainClassName = "Packer"
 project.ext.assetsDir = new File("../android/assets")
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
@@ -36,6 +35,7 @@ task dist(type: Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 dist.dependsOn classes

--- a/uigallery/build.gradle
+++ b/uigallery/build.gradle
@@ -17,9 +17,24 @@ project.ext.mainClassName = "Gallery"
 project.ext.assetsDir = new File("../android/assets")
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
 }
+
+task dist(type: Jar) {
+    from files(sourceSets.main.output.classesDirs)
+    from files(sourceSets.main.output.resourcesDir)
+    from {configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }}
+    from files(project.assetsDir)
+
+    manifest {
+        attributes 'Main-Class': project.mainClassName
+    }
+    // Required to fix this error after updating to Gradle 7.3.3:
+    // Entry META-INF/INDEX.LIST is a duplicate but no duplicate handling strategy has been set.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+dist.dependsOn classes


### PR DESCRIPTION
Google wants updated apps to use API 31 by November 1st, so let's bump versions:

- Android SDK: 31
- Android Gradle Plugin: 7.2.2 (required by Android SDK)
- Gradle: 7.3.3 (required by AGP)
- JDK: 11 (required by AGP)

Fixes #275