### PR TITLE
Fix stretched display on vehicle selection screen

### DIFF
--- a/.changes/unreleased/Fixed-20221211-104937.yaml
+++ b/.changes/unreleased/Fixed-20221211-104937.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: On devices with a screen ratio different from 16:9 the vehicle selection screen
+  was stretched and made the buttons non responsive (#296).
+time: 2022-12-11T10:49:37.160736281+01:00

--- a/core/src/com/agateau/pixelwheels/screens/VehicleDrawer.java
+++ b/core/src/com/agateau/pixelwheels/screens/VehicleDrawer.java
@@ -23,6 +23,7 @@ import com.agateau.pixelwheels.utils.BodyRegionDrawer;
 import com.agateau.pixelwheels.utils.DrawUtils;
 import com.agateau.pixelwheels.vehicledef.AxleDef;
 import com.agateau.pixelwheels.vehicledef.VehicleDef;
+import com.agateau.ui.GLViewportSaver;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -43,6 +44,7 @@ public class VehicleDrawer {
     private final Vector2 mFrameBufferCenter = new Vector2(FB_WIDTH / 2f, FB_HEIGHT / 2f);
     private final Matrix4 mFrameBufferProjectionMatrix = new Matrix4();
     private final Matrix4 mFrameBufferTransformMatrix = new Matrix4();
+    private final GLViewportSaver mViewportSaver = new GLViewportSaver();
 
     private VehicleDef mVehicleDef;
     private final Vector2 mCenter = new Vector2(0, 0);
@@ -114,6 +116,9 @@ public class VehicleDrawer {
         sOldTransformMatrix.set(batch.getTransformMatrix());
         batch.setProjectionMatrix(mFrameBufferProjectionMatrix);
         batch.setTransformMatrix(mFrameBufferTransformMatrix);
+
+        mViewportSaver.save();
+
         mFrameBuffer.begin();
         batch.begin();
         Gdx.gl.glClearColor(0, 0, 0, 0);
@@ -122,7 +127,10 @@ public class VehicleDrawer {
         drawInternal(batch, region, mFrameBufferCenter);
 
         batch.end();
-        mFrameBuffer.end();
+        // Do not use FrameBuffer.end() here because it resets the viewport and causes
+        // https://github.com/agateau/pixelwheels/issues/296
+        FrameBuffer.unbind();
+        mViewportSaver.restore();
 
         // Draw mFrameBuffer on screen
         batch.setProjectionMatrix(sOldMatrix);

--- a/core/src/com/agateau/ui/GLViewportSaver.java
+++ b/core/src/com/agateau/ui/GLViewportSaver.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.ui;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+/** Helper class to save and restore the coordinates of the GL viewport */
+public class GLViewportSaver {
+    private final IntBuffer mBuffer;
+
+    public GLViewportSaver() {
+        mBuffer = ByteBuffer.allocateDirect(4 * 4).order(ByteOrder.nativeOrder()).asIntBuffer();
+    }
+
+    public void save() {
+        Gdx.gl20.glGetIntegerv(GL20.GL_VIEWPORT, mBuffer);
+    }
+
+    public void restore() {
+        Gdx.gl20.glViewport(mBuffer.get(0), mBuffer.get(1), mBuffer.get(2), mBuffer.get(3));
+    }
+}

--- a/docs/release-check-list.md
+++ b/docs/release-check-list.md
@@ -2,74 +2,98 @@
 
 - [ ] Check source tree is clean
 
+    ```
     git checkout dev
     git pull
     git merge origin/master
     git status
+    ```
 
 - [ ] Bump version number
 
+    ```
     vi version.properties
+    ```
 
 - [ ] Bump Flatpak version number
 
+    ```
     vi tools/packaging/linux/share/metainfo/com.agateau.PixelWheels.metainfo.xml
+    ```
 
 - [ ] Update changelog
 
+    ```
     changie batch $version
     vi .changes/$version.md
     changie merge
     vi CHANGELOG.md
     vi fastlane/metadata/android/en-US/changelogs/$version.txt
+    ```
 
 - [ ] Build archives
 
     Check signing key is in android/signing.gradle
 
+    ```
     make clean-dist
+    ```
 
 - [ ] Test on computer
 
+    ```
     make desktop-run-from-dist
+    ```
 
 - [ ] Test on device
 
+    ```
     make android-run-from-dist
+    ```
 
 - [ ] Update screenshots in fastlane/metadata/android/en-US/images/
 
-- [ ] git commit
+- [ ] Commit changes
 
 - [ ] Push dev branch
 
+    ```
     git push
+    ```
 
 - [ ] Check CI is happy
 
 - [ ] Merge in master
 
+    ```
     git checkout master
     git pull
     git merge --ff-only dev
+    ```
 
 - [ ] Upload gplay apk on Google Play
 
     Check api file is in fastlane/google-play-api.json
 
+    ```
     make fastlane-beta
+    ```
 
 - [ ] Check Google Play is happy
 
 - [ ] Tag and push
 
+    ```
     make tagpush
+    ```
 
 # Upload archives
 
 - [ ] Upload archives to itch.io
 
+    ```
     make butler-upload
+    ```
 
 # Game page
 
@@ -90,7 +114,9 @@
 
 - [ ] Upload on GitHub
 
+    ```
     make gh-upload
+    ```
 
 - [ ] Update the Flathub repository <https://github.com/flathub/com.agateau.PixelWheels>
 

--- a/docs/release-check-list.md
+++ b/docs/release-check-list.md
@@ -45,7 +45,7 @@
     make desktop-run-from-dist
     ```
 
-- [ ] Test on device
+- [ ] Test on a non 16:9 device
 
     ```
     make android-run-from-dist


### PR DESCRIPTION
Do not stretch the scene to fill the screen when the display ratio is not 16:9.

Fixes #296
