### PR TITLE
Use two columns for the language selector

### DIFF
--- a/android/assets/screens/selectlanguage.gdxui
+++ b/android/assets/screens/selectlanguage.gdxui
@@ -4,7 +4,7 @@
         <Label id="mainLabel" style="title"
             topCenter="root.topCenter 0 -2">Select Language</Label>
 
-        <Menu id="menu" topCenter="mainLabel.bottomCenter 0 -2g" width="400px">
+        <Menu id="menu" topCenter="mainLabel.bottomCenter 0 -2g" width="500px">
         </Menu>
 
         <ImageButton id="backButton"

--- a/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
@@ -115,8 +115,8 @@ public class SelectLanguageScreen extends PwStageScreen {
         Array<Language> languages = mGame.getAssets().languages.getAll();
         languages.sort((l1, l2) -> l1.name.compareToIgnoreCase(l2.name));
         languageSelector.setItems(languages);
-        languageSelector.setItemSize(menu.getWidth(), ITEM_HEIGHT);
-        languageSelector.setColumnCount(1);
+        languageSelector.setItemSize(menu.getWidth() / 2 - 10, ITEM_HEIGHT);
+        languageSelector.setColumnCount(2);
         languageSelector.setTouchUiConfirmMode(GridMenuItem.TouchUiConfirmMode.SINGLE_TOUCH);
 
         HashMap<String, BitmapFont> fontForLanguage = getFontForLanguage(languages);

--- a/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectLanguageScreen.java
@@ -114,6 +114,7 @@ public class SelectLanguageScreen extends PwStageScreen {
         GridMenuItem<Language> languageSelector = new GridMenuItem<>(menu);
         Array<Language> languages = mGame.getAssets().languages.getAll();
         languages.sort((l1, l2) -> l1.name.compareToIgnoreCase(l2.name));
+        languageSelector.setItemDirection(GridMenuItem.ItemDirection.TopToBottom);
         languageSelector.setItems(languages);
         languageSelector.setItemSize(menu.getWidth() / 2 - 10, ITEM_HEIGHT);
         languageSelector.setColumnCount(2);

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -50,6 +50,12 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
     private float mItemWidth = 0;
     private float mItemHeight = 0;
     private TouchUiConfirmMode mTouchUiConfirmMode = TouchUiConfirmMode.DOUBLE_TOUCH;
+    private ItemDirection mItemDirection = ItemDirection.LeftToRight;
+
+    public enum ItemDirection {
+        LeftToRight,
+        TopToBottom
+    }
 
     public enum TouchUiConfirmMode {
         SINGLE_TOUCH,
@@ -113,6 +119,10 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
 
     public void setTouchUiConfirmMode(TouchUiConfirmMode touchUiConfirmMode) {
         mTouchUiConfirmMode = touchUiConfirmMode;
+    }
+
+    public void setItemDirection(ItemDirection itemDirection) {
+        mItemDirection = itemDirection;
     }
 
     public void setSelectionListener(SelectionListener<T> selectionListener) {
@@ -305,12 +315,22 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
             }
             mRenderer.render(batch, getX() + x, getY() + y, mItemWidth, mItemHeight, item);
 
-            if ((idx + 1) % mColumnCount == 0) {
-                // New row
-                x = 0;
-                y -= mItemHeight;
+            if (mItemDirection == ItemDirection.LeftToRight) {
+                if ((idx + 1) % mColumnCount == 0) {
+                    // New row
+                    x = 0;
+                    y -= mItemHeight;
+                } else {
+                    x += mItemWidth + itemSpacing;
+                }
             } else {
-                x += mItemWidth + itemSpacing;
+                if (y - mItemHeight < 0) {
+                    // New column
+                    x += mItemWidth + itemSpacing;
+                    y = getHeight() - mItemHeight;
+                } else {
+                    y -= mItemHeight;
+                }
             }
         }
     }
@@ -334,35 +354,67 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
 
     @Override
     public boolean goUp() {
-        if (mCurrentIndex - mColumnCount >= 0) {
-            setCurrentIndex(mCurrentIndex - mColumnCount);
-            return true;
+        if (mItemDirection == ItemDirection.LeftToRight) {
+            if (mCurrentIndex - mColumnCount >= 0) {
+                setCurrentIndex(mCurrentIndex - mColumnCount);
+                return true;
+            } else {
+                return false;
+            }
         } else {
-            return false;
+            if (mCurrentIndex > 0) {
+                setCurrentIndex(mCurrentIndex - 1);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     @Override
     public boolean goDown() {
-        if (mCurrentIndex + mColumnCount < mItems.size) {
-            setCurrentIndex(mCurrentIndex + mColumnCount);
-            return true;
+        if (mItemDirection == ItemDirection.LeftToRight) {
+            if (mCurrentIndex + mColumnCount < mItems.size) {
+                setCurrentIndex(mCurrentIndex + mColumnCount);
+                return true;
+            } else {
+                return false;
+            }
         } else {
-            return false;
+            if (mCurrentIndex < mItems.size - 1) {
+                setCurrentIndex(mCurrentIndex + 1);
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 
     @Override
     public void goLeft() {
-        if (mCurrentIndex > 0) {
-            setCurrentIndex(mCurrentIndex - 1);
+        if (mItemDirection == ItemDirection.LeftToRight) {
+            if (mCurrentIndex > 0) {
+                setCurrentIndex(mCurrentIndex - 1);
+            }
+        } else {
+            int rowCount = getRowCount();
+            if (mCurrentIndex - rowCount >= 0) {
+                setCurrentIndex(mCurrentIndex - rowCount);
+            }
         }
     }
 
     @Override
     public void goRight() {
-        if (mCurrentIndex < mItems.size - 1) {
-            setCurrentIndex(mCurrentIndex + 1);
+        if (mItemDirection == ItemDirection.LeftToRight) {
+            if (mCurrentIndex < mItems.size - 1) {
+                setCurrentIndex(mCurrentIndex + 1);
+            }
+        } else {
+            int rowCount = getRowCount();
+            if (mCurrentIndex + rowCount < mItems.size) {
+                setCurrentIndex(mCurrentIndex + rowCount);
+            }
         }
     }
 
@@ -422,5 +474,9 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         } else {
             return INVALID_INDEX;
         }
+    }
+
+    private int getRowCount() {
+        return (int) (getHeight() / mItemHeight);
     }
 }


### PR DESCRIPTION
Fixes #310.

I didn't make the selector scrollable: 2 columns is good enough for now and I should even be able to extend to 3 if need be.

![screenshot-2022-12-30-194654 513](https://user-images.githubusercontent.com/3575/210102964-44de4d02-ee72-4f2c-ae50-b44cb0bb4fb9.png)
