### PR TITLE
redirect gdx log

### DIFF
--- a/.changes/unreleased/Developers-20230107-231622.yaml
+++ b/.changes/unreleased/Developers-20230107-231622.yaml
@@ -1,0 +1,4 @@
+kind: Developers
+body: 'Logging system has been reworked: it no longer goes through Gdx logging system.
+  This fixes log messages arriving out of order.'
+time: 2023-01-07T23:16:22.189668515+01:00

--- a/android/src/main/com/agateau/pixelwheels/android/AndroidLauncher.java
+++ b/android/src/main/com/agateau/pixelwheels/android/AndroidLauncher.java
@@ -75,6 +75,7 @@ public class AndroidLauncher extends AndroidApplication {
         LogFilePrinter printer =
                 new LogFilePrinter(Constants.LOG_FILENAME, Constants.LOG_MAX_SIZE, opener);
         NLog.addPrinter(printer);
+        NLog.addPrinter(new AndroidNLogPrinter());
 
         AndroidLogExporter exporter = new AndroidLogExporter(this, printer);
         game.setLogExporter(exporter);

--- a/android/src/main/com/agateau/pixelwheels/android/AndroidNLogPrinter.java
+++ b/android/src/main/com/agateau/pixelwheels/android/AndroidNLogPrinter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.pixelwheels.android;
+
+import android.util.Log;
+import com.agateau.utils.log.NLog;
+import com.badlogic.gdx.Application;
+
+/** Implementation of NLog.Printer using Android logging facilities */
+public class AndroidNLogPrinter implements NLog.Printer {
+    @Override
+    public void print(int level, String tag, String message) {
+        int priority;
+        switch (level) {
+            case Application.LOG_DEBUG:
+                priority = Log.DEBUG;
+                break;
+            case Application.LOG_INFO:
+                priority = Log.INFO;
+                break;
+            default: // Application.LOG_ERROR:
+                priority = Log.ERROR;
+                break;
+        }
+        Log.println(priority, tag, message);
+    }
+}

--- a/android/src/main/com/agateau/pixelwheels/android/AndroidNLogPrinter.java
+++ b/android/src/main/com/agateau/pixelwheels/android/AndroidNLogPrinter.java
@@ -20,21 +20,20 @@ package com.agateau.pixelwheels.android;
 
 import android.util.Log;
 import com.agateau.utils.log.NLog;
-import com.badlogic.gdx.Application;
 
 /** Implementation of NLog.Printer using Android logging facilities */
 public class AndroidNLogPrinter implements NLog.Printer {
     @Override
-    public void print(int level, String tag, String message) {
-        int priority;
+    public void print(NLog.Level level, String tag, String message) {
+        int priority = Log.ERROR;
         switch (level) {
-            case Application.LOG_DEBUG:
+            case DEBUG:
                 priority = Log.DEBUG;
                 break;
-            case Application.LOG_INFO:
+            case INFO:
                 priority = Log.INFO;
                 break;
-            default: // Application.LOG_ERROR:
+            case ERROR:
                 priority = Log.ERROR;
                 break;
         }

--- a/core-tests/src/com/agateau/utils/log/LogFilePrinterTests.java
+++ b/core-tests/src/com/agateau/utils/log/LogFilePrinterTests.java
@@ -44,10 +44,10 @@ public class LogFilePrinterTests {
 
         LogFilePrinter printer = new LogFilePrinter(path, 200);
         printer.setMessageFormatter(
-                (level, tag, message) -> String.format(Locale.US, "%d %s %s", level, tag, message));
-        printer.print(12, "tag", "hello");
+                (level, tag, message) -> String.format(Locale.US, "%s %s %s", level, tag, message));
+        printer.print(NLog.Level.INFO, "tag", "hello");
 
-        assertThat(readFile(path), is("12 tag hello\n"));
+        assertThat(readFile(path), is("INFO tag hello\n"));
     }
 
     @Test
@@ -59,19 +59,19 @@ public class LogFilePrinterTests {
         printer.setMessageFormatter((level, tag, message) -> message);
 
         // WHEN I log a short message
-        printer.print(0, "", "aaaaa");
+        printer.print(NLog.Level.INFO, "", "aaaaa");
 
         // THEN it is in the main log
         assertThat(readFile(path), is("aaaaa\n"));
 
         // WHEN I log another short message
-        printer.print(0, "", "bbbbb");
+        printer.print(NLog.Level.INFO, "", "bbbbb");
 
         // THEN it iis also in the main log
         assertThat(readFile(path), is("aaaaa\nbbbbb\n"));
 
         // WHEN I log a message which forces the rotation
-        printer.print(0, "", "0123456789abcde");
+        printer.print(NLog.Level.INFO, "", "0123456789abcde");
 
         // THEN the backup log contains the previous content
         assertThat(readFile(path + LogFilePrinter.BACKUP_SUFFIX), is("aaaaa\nbbbbb\n"));
@@ -80,7 +80,7 @@ public class LogFilePrinterTests {
         assertThat(readFile(path), is("0123456789abcde\n"));
 
         // WHEN I log another long message
-        printer.print(0, "", "edcba0123456789");
+        printer.print(NLog.Level.INFO, "", "edcba0123456789");
 
         // THEN the backup log contains the previous main log content
         assertThat(readFile(path + LogFilePrinter.BACKUP_SUFFIX), is("0123456789abcde\n"));

--- a/core/src/com/agateau/pixelwheels/PwGame.java
+++ b/core/src/com/agateau/pixelwheels/PwGame.java
@@ -41,8 +41,8 @@ import com.agateau.utils.FileUtils;
 import com.agateau.utils.Introspector;
 import com.agateau.utils.PlatformUtils;
 import com.agateau.utils.ScreenshotCreator;
-import com.agateau.utils.log.GdxPrinter;
 import com.agateau.utils.log.NLog;
+import com.agateau.utils.log.NLogGdxApplicationLogger;
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
@@ -112,9 +112,9 @@ public class PwGame extends Game implements GameConfig.ChangeListener {
 
     @Override
     public void create() {
-        // Adding the printer must be done only now because it requires
+        // Installing the GdxApplicationLogger must be done only now because it requires
         // Gdx.app to be initialized
-        NLog.addPrinter(new GdxPrinter());
+        NLogGdxApplicationLogger.install();
 
         logStartup();
 

--- a/core/src/com/agateau/utils/log/LogFilePrinter.java
+++ b/core/src/com/agateau/utils/log/LogFilePrinter.java
@@ -18,7 +18,6 @@
  */
 package com.agateau.utils.log;
 
-import com.badlogic.gdx.Application;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -44,7 +43,7 @@ public class LogFilePrinter implements NLog.Printer {
     }
 
     public interface MessageFormatter {
-        String formatMessage(int level, String tag, String message);
+        String formatMessage(NLog.Level level, String tag, String message);
     }
 
     public String getPath() {
@@ -64,13 +63,13 @@ public class LogFilePrinter implements NLog.Printer {
                 private final StringBuilder mStringBuilder = new StringBuilder();
 
                 @Override
-                public String formatMessage(int level, String tag, String message) {
+                public String formatMessage(NLog.Level level, String tag, String message) {
                     String levelString;
-                    if (level == Application.LOG_DEBUG) {
+                    if (level == NLog.Level.DEBUG) {
                         levelString = "D";
-                    } else if (level == Application.LOG_INFO) {
+                    } else if (level == NLog.Level.INFO) {
                         levelString = "I";
-                    } else { // LOG_ERROR
+                    } else { // ERROR
                         levelString = "E";
                     }
                     mStringBuilder.setLength(0);
@@ -114,7 +113,7 @@ public class LogFilePrinter implements NLog.Printer {
     }
 
     @Override
-    public void print(int level, String tag, String message) {
+    public void print(NLog.Level level, String tag, String message) {
         if (mStream == null) {
             return;
         }

--- a/core/src/com/agateau/utils/log/NLog.java
+++ b/core/src/com/agateau/utils/log/NLog.java
@@ -18,7 +18,6 @@
  */
 package com.agateau.utils.log;
 
-import com.badlogic.gdx.Application;
 import java.util.Vector;
 
 /**
@@ -36,20 +35,26 @@ public class NLog {
     private static final Vector<Printer> sPrinters = new Vector<>();
     private static int sStackDepth = -1;
 
+    public enum Level {
+        DEBUG,
+        INFO,
+        ERROR,
+    }
+
     public interface Printer {
-        void print(int level, String tag, String message);
+        void print(Level level, String tag, String message);
     }
 
     public static void d(Object obj, Object... args) {
-        print(Application.LOG_DEBUG, obj, args);
+        print(Level.DEBUG, obj, args);
     }
 
     public static void i(Object obj, Object... args) {
-        print(Application.LOG_INFO, obj, args);
+        print(Level.INFO, obj, args);
     }
 
     public static void e(Object obj, Object... args) {
-        print(Application.LOG_ERROR, obj, args);
+        print(Level.ERROR, obj, args);
     }
 
     public static void backtrace() {
@@ -63,14 +68,14 @@ public class NLog {
         sPrinters.add(printer);
     }
 
-    static synchronized void print(int level, Object obj, Object... args) {
+    static synchronized void print(Level level, Object obj, Object... args) {
         if (sStackDepth < 0) {
             initStackDepth();
         }
         print(level, getCallerMethod(), obj, args);
     }
 
-    static synchronized void print(int level, String tag, Object obj, Object... args) {
+    static synchronized void print(Level level, String tag, Object obj, Object... args) {
         String message;
         if (obj == null) {
             message = "(null)";

--- a/core/src/com/agateau/utils/log/NLogGdxApplicationLogger.java
+++ b/core/src/com/agateau/utils/log/NLogGdxApplicationLogger.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.utils.log;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.ApplicationLogger;
+import com.badlogic.gdx.Gdx;
+
+/** Implementation of Gdx ApplicationLogger to route Gdx logs through NLog */
+public class NLogGdxApplicationLogger implements ApplicationLogger {
+    public static void install() {
+        Gdx.app.setApplicationLogger(new NLogGdxApplicationLogger());
+    }
+
+    @Override
+    public void log(String tag, String message) {
+        NLog.print(Application.LOG_INFO, tag, message);
+    }
+
+    @Override
+    public void log(String tag, String message, Throwable exception) {
+        NLog.print(
+                Application.LOG_INFO, tag, "%s. Exception: %s", message, exception.getStackTrace());
+    }
+
+    @Override
+    public void error(String tag, String message) {
+        NLog.print(Application.LOG_ERROR, tag, message);
+    }
+
+    @Override
+    public void error(String tag, String message, Throwable exception) {
+        NLog.print(
+                Application.LOG_ERROR,
+                tag,
+                "%s. Exception: %s",
+                message,
+                exception.getStackTrace());
+    }
+
+    @Override
+    public void debug(String tag, String message) {
+        NLog.print(Application.LOG_DEBUG, tag, message);
+    }
+
+    @Override
+    public void debug(String tag, String message, Throwable exception) {
+        NLog.print(
+                Application.LOG_DEBUG,
+                tag,
+                "%s. Exception: %s",
+                message,
+                exception.getStackTrace());
+    }
+}

--- a/core/src/com/agateau/utils/log/NLogGdxApplicationLogger.java
+++ b/core/src/com/agateau/utils/log/NLogGdxApplicationLogger.java
@@ -18,7 +18,6 @@
  */
 package com.agateau.utils.log;
 
-import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationLogger;
 import com.badlogic.gdx.Gdx;
 
@@ -30,42 +29,31 @@ public class NLogGdxApplicationLogger implements ApplicationLogger {
 
     @Override
     public void log(String tag, String message) {
-        NLog.print(Application.LOG_INFO, tag, message);
+        NLog.print(NLog.Level.INFO, tag, message);
     }
 
     @Override
     public void log(String tag, String message, Throwable exception) {
-        NLog.print(
-                Application.LOG_INFO, tag, "%s. Exception: %s", message, exception.getStackTrace());
+        NLog.print(NLog.Level.INFO, tag, "%s. Exception: %s", message, exception.getStackTrace());
     }
 
     @Override
     public void error(String tag, String message) {
-        NLog.print(Application.LOG_ERROR, tag, message);
+        NLog.print(NLog.Level.ERROR, tag, message);
     }
 
     @Override
     public void error(String tag, String message, Throwable exception) {
-        NLog.print(
-                Application.LOG_ERROR,
-                tag,
-                "%s. Exception: %s",
-                message,
-                exception.getStackTrace());
+        NLog.print(NLog.Level.ERROR, tag, "%s. Exception: %s", message, exception.getStackTrace());
     }
 
     @Override
     public void debug(String tag, String message) {
-        NLog.print(Application.LOG_DEBUG, tag, message);
+        NLog.print(NLog.Level.DEBUG, tag, message);
     }
 
     @Override
     public void debug(String tag, String message, Throwable exception) {
-        NLog.print(
-                Application.LOG_DEBUG,
-                tag,
-                "%s. Exception: %s",
-                message,
-                exception.getStackTrace());
+        NLog.print(NLog.Level.DEBUG, tag, "%s. Exception: %s", message, exception.getStackTrace());
     }
 }

--- a/core/src/com/agateau/utils/log/SystemErrPrinter.java
+++ b/core/src/com/agateau/utils/log/SystemErrPrinter.java
@@ -18,21 +18,23 @@
  */
 package com.agateau.utils.log;
 
-import com.badlogic.gdx.Application;
-
 /** Implementation of Printer which logs to System.err */
 public class SystemErrPrinter implements NLog.Printer {
     private final StringBuilder mStringBuilder = new StringBuilder();
 
     @Override
-    public void print(int level, String tag, String message) {
-        String levelString;
-        if (level == Application.LOG_DEBUG) {
-            levelString = "D";
-        } else if (level == Application.LOG_INFO) {
-            levelString = "I";
-        } else { // LOG_ERROR
-            levelString = "E";
+    public void print(NLog.Level level, String tag, String message) {
+        String levelString = "?";
+        switch (level) {
+            case DEBUG:
+                levelString = "D";
+                break;
+            case INFO:
+                levelString = "I";
+                break;
+            case ERROR:
+                levelString = "E";
+                break;
         }
         mStringBuilder.setLength(0);
 

--- a/core/src/com/agateau/utils/log/SystemErrPrinter.java
+++ b/core/src/com/agateau/utils/log/SystemErrPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Aurélien Gâteau <mail@agateau.com>
+ * Copyright 2023 Aurélien Gâteau <mail@agateau.com>
  *
  * This file is part of Pixel Wheels.
  *
@@ -19,39 +19,32 @@
 package com.agateau.utils.log;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 
-/** Implementation of Printer using Gdx.app logging facilities */
-public class GdxPrinter implements NLog.Printer {
-    private final String mPrefix;
+/** Implementation of Printer which logs to System.err */
+public class SystemErrPrinter implements NLog.Printer {
     private final StringBuilder mStringBuilder = new StringBuilder();
-
-    public GdxPrinter() {
-        this("");
-    }
-
-    public GdxPrinter(String prefix) {
-        mPrefix = prefix.isEmpty() ? "" : (prefix + ".");
-        Gdx.app.setLogLevel(Application.LOG_DEBUG);
-    }
 
     @Override
     public void print(int level, String tag, String message) {
-        tag = mPrefix + tag;
-
-        // Add timestamp
-        mStringBuilder.setLength(0);
-        NLogPrinterUtils.appendTimeStamp(mStringBuilder);
-        mStringBuilder.append(' ');
-        mStringBuilder.append(message);
-        message = mStringBuilder.toString();
-
+        String levelString;
         if (level == Application.LOG_DEBUG) {
-            Gdx.app.debug(tag, message);
+            levelString = "D";
         } else if (level == Application.LOG_INFO) {
-            Gdx.app.log(tag, message);
+            levelString = "I";
         } else { // LOG_ERROR
-            Gdx.app.error(tag, message);
+            levelString = "E";
         }
+        mStringBuilder.setLength(0);
+
+        NLogPrinterUtils.appendTimeStamp(mStringBuilder);
+
+        mStringBuilder.append(' ');
+        mStringBuilder.append(levelString);
+
+        mStringBuilder.append(" [");
+        mStringBuilder.append(tag);
+        mStringBuilder.append("] ");
+        mStringBuilder.append(message);
+        System.err.println(mStringBuilder);
     }
 }

--- a/desktop/src/com/agateau/pixelwheels/desktop/DesktopLauncher.java
+++ b/desktop/src/com/agateau/pixelwheels/desktop/DesktopLauncher.java
@@ -25,6 +25,7 @@ import com.agateau.pixelwheels.utils.StringUtils;
 import com.agateau.utils.FileUtils;
 import com.agateau.utils.log.LogFilePrinter;
 import com.agateau.utils.log.NLog;
+import com.agateau.utils.log.SystemErrPrinter;
 import com.badlogic.gdx.Files;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
@@ -60,6 +61,7 @@ public class DesktopLauncher {
         String logFilePath = cacheDir + File.separator + Constants.LOG_FILENAME;
         LogFilePrinter printer = new LogFilePrinter(logFilePath, Constants.LOG_MAX_SIZE);
         NLog.addPrinter(printer);
+        NLog.addPrinter(new SystemErrPrinter());
 
         game.setLogExporter(new DesktopLogExporter(printer));
     }


### PR DESCRIPTION
- Refactor NLog: now Gdx logs go through NLog instead of NLog using Gdx logs
- NLog now uses its own enum for log levels
- Add changelog entry
