### PR TITLE
Use a predefined order to decide fall back input handlers

### DIFF
--- a/.changes/unreleased/Fixed-20230911-183603.yaml
+++ b/.changes/unreleased/Fixed-20230911-183603.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Fixed an issue where the game would complain about a missing controller when started
+  on Android (#398).
+time: 2023-09-11T18:36:03.494819314+02:00

--- a/core-tests/src/com/agateau/pixelwheels/GameConfigTest.java
+++ b/core-tests/src/com/agateau/pixelwheels/GameConfigTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Tiny Wheels is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.agateau.pixelwheels;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.agateau.pixelwheels.gameinput.GameInputHandler;
+import com.agateau.pixelwheels.gameinput.GameInputHandlerFactories;
+import com.agateau.utils.TestGdxPreferences;
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.utils.Array;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GameConfigTest {
+
+    @Test
+    public void setupInputHandlers_DesktopBlankState() {
+        // GIVEN a device without touchscreen
+        Input input = mock(Input.class);
+        when(input.isPeripheralAvailable(Input.Peripheral.MultitouchScreen)).thenReturn(false);
+        Gdx.input = input;
+
+        Gdx.app = mock(Application.class);
+
+        // WHEN creating the default config
+        GameConfig config = new GameConfig(new TestGdxPreferences());
+
+        // THEN handlers for the players are the 4 keyboard handlers
+        Array<GameInputHandler> keyboardHandlers =
+                GameInputHandlerFactories.getFactoryById("keyboard").getAllHandlers();
+
+        for (int idx = 0; idx < Constants.MAX_PLAYERS; ++idx) {
+            GameInputHandler handler = config.getPlayerInputHandler(idx);
+            GameInputHandler keyboardHandler = keyboardHandlers.get(idx);
+            assertThat("idx=" + idx, handler, is(keyboardHandler));
+        }
+    }
+
+    @Test
+    public void setupInputHandlers_PhoneBlankState() {
+        // GIVEN a device with a touchscreen
+        Input input = mock(Input.class);
+        when(input.isPeripheralAvailable(Input.Peripheral.MultitouchScreen)).thenReturn(true);
+        Gdx.input = input;
+
+        Gdx.app = mock(Application.class);
+
+        // WHEN creating the default config
+        GameConfig config = new GameConfig(new TestGdxPreferences());
+
+        // THEN the input handler for player 1 is the PieTouchHandler
+        GameInputHandler pieTouchHandler =
+                GameInputHandlerFactories.getFactoryById("pie").getAllHandlers().first();
+
+        GameInputHandler p1Handler = config.getPlayerInputHandler(0);
+        assertThat(p1Handler, is(pieTouchHandler));
+    }
+}

--- a/core-tests/src/com/agateau/utils/TestGdxPreferences.java
+++ b/core-tests/src/com/agateau/utils/TestGdxPreferences.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 Aurélien Gâteau <mail@agateau.com>
+ *
+ * This file is part of Pixel Wheels.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.agateau.utils;
+
+import com.badlogic.gdx.Preferences;
+import java.util.Map;
+
+/**
+ * A test implementation of Gdx.preferences
+ *
+ * <p>Returns the default value for all `get*(key, defaultValue)`.
+ */
+public class TestGdxPreferences implements Preferences {
+    @Override
+    public Preferences putBoolean(String key, boolean val) {
+        return this;
+    }
+
+    @Override
+    public Preferences putInteger(String key, int val) {
+        return this;
+    }
+
+    @Override
+    public Preferences putLong(String key, long val) {
+        return this;
+    }
+
+    @Override
+    public Preferences putFloat(String key, float val) {
+        return this;
+    }
+
+    @Override
+    public Preferences putString(String key, String val) {
+        return this;
+    }
+
+    @Override
+    public Preferences put(Map<String, ?> vals) {
+        return this;
+    }
+
+    @Override
+    public boolean getBoolean(String key) {
+        return false;
+    }
+
+    @Override
+    public int getInteger(String key) {
+        return 0;
+    }
+
+    @Override
+    public long getLong(String key) {
+        return 0;
+    }
+
+    @Override
+    public float getFloat(String key) {
+        return 0;
+    }
+
+    @Override
+    public String getString(String key) {
+        return "";
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defValue) {
+        return defValue;
+    }
+
+    @Override
+    public int getInteger(String key, int defValue) {
+        return defValue;
+    }
+
+    @Override
+    public long getLong(String key, long defValue) {
+        return defValue;
+    }
+
+    @Override
+    public float getFloat(String key, float defValue) {
+        return defValue;
+    }
+
+    @Override
+    public String getString(String key, String defValue) {
+        return defValue;
+    }
+
+    @Override
+    public Map<String, ?> get() {
+        return null;
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return false;
+    }
+
+    @Override
+    public void clear() {}
+
+    @Override
+    public void remove(String key) {}
+
+    @Override
+    public void flush() {}
+}

--- a/core/src/com/agateau/pixelwheels/GameConfig.java
+++ b/core/src/com/agateau/pixelwheels/GameConfig.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.DelayedRemovalArray;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** The game configuration */
@@ -54,8 +55,11 @@ public class GameConfig {
     private final DelayedRemovalArray<ChangeListener> mListeners = new DelayedRemovalArray<>();
 
     GameConfig() {
-        mPreferences = Gdx.app.getPreferences(Constants.CONFIG_FILENAME);
+        this(Gdx.app.getPreferences(Constants.CONFIG_FILENAME));
+    }
 
+    GameConfig(Preferences preferences) {
+        mPreferences = preferences;
         load();
     }
 
@@ -116,10 +120,6 @@ public class GameConfig {
         mListeners.end();
     }
 
-    public GameInputHandler[] getPlayerInputHandlers() {
-        return mPlayerInputHandlers;
-    }
-
     public GameInputHandler getPlayerInputHandler(int index) {
         Assert.check(
                 index < mPlayerInputHandlers.length,
@@ -160,10 +160,24 @@ public class GameConfig {
         return object.getClass().getSimpleName() + '@' + address;
     }
 
+    /**
+     * Initialize mPlayerInputHandlers. It does so by getting a *copy* of the input handler pointers
+     * and dispatching them to mPlayerInputHandlers.
+     */
     private void setupInputHandlers() {
         NLog.i("");
-        Map<String, Array<GameInputHandler>> inputHandlersByIds =
-                GameInputHandlerFactories.getInputHandlersByIds();
+
+        // Create a map mapping an input handler factory ID to a *copy* of its handler array.
+        //
+        // It's a copy so that code can take handlers from the array without affecting the original.
+        //
+        // The map is a LinkedHashMap so that iterating on the entries follows the order factories
+        // are listed inside GameInputHandlerFactories, ensuring factories listed early are picked
+        // first when selecting a default handler.
+        LinkedHashMap<String, Array<GameInputHandler>> inputHandlersByIds = new LinkedHashMap<>();
+        for (GameInputHandlerFactory factory : GameInputHandlerFactories.getAvailableFactories()) {
+            inputHandlersByIds.put(factory.getId(), new Array<>(factory.getAllHandlers()));
+        }
 
         for (int idx = 0; idx < Constants.MAX_PLAYERS; ++idx) {
             mPlayerInputHandlers[idx] = null;
@@ -181,6 +195,11 @@ public class GameConfig {
                 }
             }
             if (inputHandler == null) {
+                // We haven't found an input handler for this player, fall back to the first
+                // available handler.
+                NLog.i(
+                        "P%d: no predefined config, or predefined config not available. Looking for a fallback.",
+                        idx + 1);
                 for (Map.Entry<String, Array<GameInputHandler>> entry :
                         inputHandlersByIds.entrySet()) {
                     inputHandler = popInputHandler(entry.getValue());

--- a/core/src/com/agateau/pixelwheels/gameinput/GameInputHandlerFactories.java
+++ b/core/src/com/agateau/pixelwheels/gameinput/GameInputHandlerFactories.java
@@ -23,8 +23,6 @@ import com.agateau.utils.log.NLog;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.utils.Array;
-import java.util.HashMap;
-import java.util.Map;
 
 /** Provides input handlers */
 public class GameInputHandlerFactories {
@@ -33,15 +31,6 @@ public class GameInputHandlerFactories {
     public static Array<GameInputHandlerFactory> getAvailableFactories() {
         init();
         return sFactories;
-    }
-
-    public static Map<String, Array<GameInputHandler>> getInputHandlersByIds() {
-        init();
-        Map<String, Array<GameInputHandler>> map = new HashMap<>();
-        for (GameInputHandlerFactory factory : sFactories) {
-            map.put(factory.getId(), new Array<>(factory.getAllHandlers()));
-        }
-        return map;
     }
 
     public static GameInputHandlerFactory getFactoryById(String id) {


### PR DESCRIPTION
Ensures a touch-screen device falls back to a touch-screen input handler
instead of the keyboard handler.

Add tests.

Should fix #398
