### PR TITLE
Fix rare crash when missile explodes before audioRender() has been called

### DIFF
--- a/core/src/com/agateau/pixelwheels/bonus/Missile.java
+++ b/core/src/com/agateau/pixelwheels/bonus/Missile.java
@@ -72,7 +72,6 @@ public class Missile extends GameObjectAdapter
     private static final float SHOT_DENSITY = 0.0001f;
     private static final Color TARGETED_COLOR = new Color(1, 1, 1, 0.7f);
     private static final Color LOCKED_COLOR = new Color(1, 0.3f, 0.3f, 0.9f);
-    private SoundPlayer mSoundPlayer;
 
     enum Status {
         WAITING,
@@ -88,6 +87,7 @@ public class Missile extends GameObjectAdapter
     private final ClosestRacerFinder mRacerFinder = new ClosestRacerFinder(LOCK_DISTANCE, LOCK_ARC);
     private final MissileGuidingSystem mGuidingSystem = new MissileGuidingSystem();
     private Assets mAssets;
+    private SoundPlayer mSoundPlayer;
 
     private final DebugShapeMap.Shape mDebugShape =
             new DebugShapeMap.Shape() {
@@ -148,6 +148,9 @@ public class Missile extends GameObjectAdapter
                         | CollisionCategories.EXPLOSABLE);
 
         object.mStatus = Status.WAITING;
+        if (object.mSoundPlayer == null) {
+            object.mSoundPlayer = audioManager.createSoundPlayer(assets.soundAtlas.get("missile"));
+        }
         object.mNeedShootSound = false;
         object.mTarget = null;
         object.initJoint();
@@ -313,7 +316,6 @@ public class Missile extends GameObjectAdapter
     @Override
     public void audioRender(AudioClipper clipper) {
         if (mNeedShootSound) {
-            mSoundPlayer = mAudioManager.createSoundPlayer(mAssets.soundAtlas.get("missile"));
             mSoundPlayer.setVolume(clipper.clip(this));
             mSoundPlayer.play();
 


### PR DESCRIPTION
This has been reported by Google Play review system as a crash in Missile.explode(), caused by mSoundPlayer being null:

```
Exception java.lang.NullPointerException: Attempt to invoke interface method 'void com.agateau.pixelwheels.sound.SoundPlayer.stop()' on a null object reference
  at com.agateau.pixelwheels.bonus.Missile.explode (Missile.java:343)
  at com.agateau.pixelwheels.bonus.Missile.preSolve (Missile.java:368)
  at com.agateau.pixelwheels.racescreen.GameWorldImpl.preSolve (GameWorldImpl.java:374)
  at com.badlogic.gdx.physics.box2d.World.preSolve (World.java:1003)
  at com.badlogic.gdx.physics.box2d.World.jniStep
  at com.badlogic.gdx.physics.box2d.World.step (World.java:691)
  at com.agateau.pixelwheels.racescreen.GameWorldImpl.act (GameWorldImpl.java:193)
  at com.agateau.pixelwheels.racescreen.RaceScreen.render (RaceScreen.java:218)
  at com.badlogic.gdx.Game.render (Game.java:46)
  at com.agateau.pixelwheels.PwGame.render (PwGame.java:179)
  at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame (AndroidGraphics.java:471)
  at android.opengl.GLSurfaceView$GLThread.guardedRun (GLSurfaceView.java:1573)
  at android.opengl.GLSurfaceView$GLThread.run (GLSurfaceView.java:1272)
```