### PR TITLE
heading-up-mode

### DIFF
--- a/.changes/unreleased/Added-20240505-230711.yaml
+++ b/.changes/unreleased/Added-20240505-230711.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: The "rotate camera" option is back! Thanks to Compl Yue for this work!
+time: 2024-05-05T23:07:11.238258542+02:00

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           pip install -r requirements.txt
           sudo apt-get update
           sudo apt-get install -y gettext libxml2-utils
+          tools/apply-codingstyle --download-only
 
       - name: Run pre-commit
         run: pre-commit run --all

--- a/android/assets/po/bn.po
+++ b/android/assets/po/bn.po
@@ -856,7 +856,7 @@ msgstr "সংগীত প্রভাব:"
 msgid "Music:"
 msgstr "সংগীত"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "ভিডিও"
 
@@ -864,7 +864,13 @@ msgstr "ভিডিও"
 msgid "Fullscreen:"
 msgstr "বড়পর্দা"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "পাল্টাও"
 

--- a/android/assets/po/de.po
+++ b/android/assets/po/de.po
@@ -837,7 +837,7 @@ msgstr "Effekte:"
 msgid "Music:"
 msgstr "Musik:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Anzeige"
 
@@ -845,7 +845,13 @@ msgstr "Anzeige"
 msgid "Fullscreen:"
 msgstr "Vollbildmodus:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "KONFIGURIEREN"
 

--- a/android/assets/po/eo.po
+++ b/android/assets/po/eo.po
@@ -841,7 +841,7 @@ msgstr "Sono FX:"
 msgid "Music:"
 msgstr "Muziko:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Video"
 
@@ -849,7 +849,13 @@ msgstr "Video"
 msgid "Fullscreen:"
 msgstr "Plenekrane:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "AGORDI"
 

--- a/android/assets/po/es.po
+++ b/android/assets/po/es.po
@@ -844,7 +844,7 @@ msgstr "Efectos de sonido:"
 msgid "Music:"
 msgstr "Música:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Vídeo"
 
@@ -852,7 +852,13 @@ msgstr "Vídeo"
 msgid "Fullscreen:"
 msgstr "Pantalla completa:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "CONFIGURAR"
 

--- a/android/assets/po/eu.po
+++ b/android/assets/po/eu.po
@@ -838,7 +838,7 @@ msgstr "Soinu efektuak:"
 msgid "Music:"
 msgstr "Musika:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Bideoa"
 
@@ -846,7 +846,13 @@ msgstr "Bideoa"
 msgid "Fullscreen:"
 msgstr "Pantaila osoa:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "KONFIGURATU"
 

--- a/android/assets/po/fr.po
+++ b/android/assets/po/fr.po
@@ -837,7 +837,7 @@ msgstr "Effets sonores :"
 msgid "Music:"
 msgstr "Musique :"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Vidéo"
 
@@ -845,7 +845,13 @@ msgstr "Vidéo"
 msgid "Fullscreen:"
 msgstr "Plein écran :"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "CONFIGURER"
 

--- a/android/assets/po/hu.po
+++ b/android/assets/po/hu.po
@@ -841,7 +841,7 @@ msgstr "Hanghatások:"
 msgid "Music:"
 msgstr "Zene:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Videó"
 
@@ -849,7 +849,13 @@ msgstr "Videó"
 msgid "Fullscreen:"
 msgstr "Teljes képernyő:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "BEÁLLÍTÁS"
 

--- a/android/assets/po/it_IT.po
+++ b/android/assets/po/it_IT.po
@@ -847,7 +847,7 @@ msgstr "Effetti sonori:"
 msgid "Music:"
 msgstr "Musica:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Video"
 
@@ -855,7 +855,13 @@ msgstr "Video"
 msgid "Fullscreen:"
 msgstr "Schermo pieno:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "CONFIGURA"
 

--- a/android/assets/po/messages.pot
+++ b/android/assets/po/messages.pot
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Music:"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr ""
 
@@ -839,7 +839,13 @@ msgstr ""
 msgid "Fullscreen:"
 msgstr ""
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr ""
 

--- a/android/assets/po/nl.po
+++ b/android/assets/po/nl.po
@@ -842,7 +842,7 @@ msgstr "Geluidseffecten:"
 msgid "Music:"
 msgstr "Muziek:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Video"
 
@@ -852,7 +852,13 @@ msgstr ""
 "Schermvullende\n"
 "weergave:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "INSTELLEN"
 

--- a/android/assets/po/pl.po
+++ b/android/assets/po/pl.po
@@ -840,7 +840,7 @@ msgstr "Efekty dźwiękowe:"
 msgid "Music:"
 msgstr "Muzyka:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Wideo"
 
@@ -848,7 +848,13 @@ msgstr "Wideo"
 msgid "Fullscreen:"
 msgstr "Pełny ekran:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "KONFIGURUJ"
 

--- a/android/assets/po/ru.po
+++ b/android/assets/po/ru.po
@@ -843,7 +843,7 @@ msgstr "Эффекты:"
 msgid "Music:"
 msgstr "Музыка:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Видео"
 
@@ -851,7 +851,13 @@ msgstr "Видео"
 msgid "Fullscreen:"
 msgstr "На весь экран:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "НАСТРОИТЬ"
 

--- a/android/assets/po/sv.po
+++ b/android/assets/po/sv.po
@@ -848,7 +848,7 @@ msgstr "Ljudeffekter:"
 msgid "Music:"
 msgstr "Musik:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Video"
 
@@ -856,7 +856,13 @@ msgstr "Video"
 msgid "Fullscreen:"
 msgstr "Helskärm:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "KONFIGURERA"
 

--- a/android/assets/po/tr.po
+++ b/android/assets/po/tr.po
@@ -836,7 +836,7 @@ msgstr "Ses Efektleri:"
 msgid "Music:"
 msgstr "Müzik:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "Video"
 
@@ -844,7 +844,13 @@ msgstr "Video"
 msgid "Fullscreen:"
 msgstr "Tam ekran:"
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "DÜZENLE"
 

--- a/android/assets/po/zh_CN.po
+++ b/android/assets/po/zh_CN.po
@@ -843,7 +843,7 @@ msgstr "音效："
 msgid "Music:"
 msgstr "音乐："
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:273
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:272
 msgid "Video"
 msgstr "画面"
 
@@ -851,7 +851,13 @@ msgstr "画面"
 msgid "Fullscreen:"
 msgstr "全屏："
 
-#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:313
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:302
+msgid ""
+"Rotate camera\n"
+"(experimental):"
+msgstr ""
+
+#: core/src/com/agateau/pixelwheels/screens/ConfigScreen.java:327
 msgid "CONFIGURE"
 msgstr "配置"
 

--- a/core/src/com/agateau/pixelwheels/GameConfig.java
+++ b/core/src/com/agateau/pixelwheels/GameConfig.java
@@ -38,6 +38,8 @@ public class GameConfig {
     }
 
     public boolean fullscreen = false;
+    public boolean headingUpCamera = false;
+
     public boolean playSoundFx = true;
     public boolean playMusic = true;
     public String languageId = "";
@@ -65,6 +67,7 @@ public class GameConfig {
 
     private void load() {
         fullscreen = mPreferences.getBoolean(PrefConstants.FULLSCREEN, false);
+        headingUpCamera = mPreferences.getBoolean(PrefConstants.HEADING_UP_CAMERA, false);
         playSoundFx = mPreferences.getBoolean(PrefConstants.SOUND_FX, true);
         playMusic = mPreferences.getBoolean(PrefConstants.MUSIC, true);
 
@@ -95,6 +98,7 @@ public class GameConfig {
 
     public void flush() {
         mPreferences.putBoolean(PrefConstants.FULLSCREEN, fullscreen);
+        mPreferences.putBoolean(PrefConstants.HEADING_UP_CAMERA, headingUpCamera);
         mPreferences.putBoolean(PrefConstants.SOUND_FX, playSoundFx);
         mPreferences.putBoolean(PrefConstants.MUSIC, playMusic);
 

--- a/core/src/com/agateau/pixelwheels/GamePlay.java
+++ b/core/src/com/agateau/pixelwheels/GamePlay.java
@@ -54,7 +54,6 @@ public class GamePlay {
 
     public boolean oneLapOnly = false;
     public boolean freeCamera = false;
-    public boolean headingUpCamera = true;
 
     public static final GamePlay instance = new GamePlay();
 }

--- a/core/src/com/agateau/pixelwheels/GamePlay.java
+++ b/core/src/com/agateau/pixelwheels/GamePlay.java
@@ -55,5 +55,12 @@ public class GamePlay {
     public boolean oneLapOnly = false;
     public boolean freeCamera = false;
 
+    public static enum CameraMode {
+        ClassicCamera,
+        HeadingUpCamera,
+    }
+
+    public CameraMode cameraMode = CameraMode.HeadingUpCamera;
+
     public static final GamePlay instance = new GamePlay();
 }

--- a/core/src/com/agateau/pixelwheels/GamePlay.java
+++ b/core/src/com/agateau/pixelwheels/GamePlay.java
@@ -54,13 +54,7 @@ public class GamePlay {
 
     public boolean oneLapOnly = false;
     public boolean freeCamera = false;
-
-    public static enum CameraMode {
-        ClassicCamera,
-        HeadingUpCamera,
-    }
-
-    public CameraMode cameraMode = CameraMode.HeadingUpCamera;
+    public boolean headingUpCamera = true;
 
     public static final GamePlay instance = new GamePlay();
 }

--- a/core/src/com/agateau/pixelwheels/PrefConstants.java
+++ b/core/src/com/agateau/pixelwheels/PrefConstants.java
@@ -30,4 +30,5 @@ public class PrefConstants {
     public static final String FULLSCREEN = "fullscreen";
     public static final String GAME_MODE = "gameMode";
     public static final String LANGUAGE_ID = "languageId";
+    public static final String HEADING_UP_CAMERA = "headingUpCamera";
 }

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -39,7 +39,7 @@ abstract class CameraUpdater {
         float viewportWidth;
         float viewportHeight;
         Vector2 position = new Vector2();
-        float cameraUp = 0;
+        float cameraUp = MathUtils.HALF_PI;
         float cameraAhead = 0;
         float zoom = 1;
 

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -18,7 +18,6 @@
  */
 package com.agateau.pixelwheels.racescreen;
 
-import com.agateau.pixelwheels.GamePlay;
 import com.agateau.pixelwheels.GameWorld;
 import com.agateau.pixelwheels.map.Track;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -78,14 +77,11 @@ abstract class CameraUpdater {
 
     void applyChanges() {
         // Apply changes
-        if (GamePlay.instance.headingUpCamera) {
-            mCamera.up.set(
-                    (float) Math.cos(mNextCameraInfo.cameraUp),
-                    (float) Math.sin(mNextCameraInfo.cameraUp),
-                    0);
-        } else {
-            mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
-        }
+        mCamera.up.set(
+                MathUtils.cos(mNextCameraInfo.cameraUp),
+                MathUtils.sin(mNextCameraInfo.cameraUp),
+                0);
+
         mCamera.viewportWidth = mNextCameraInfo.viewportWidth;
         mCamera.viewportHeight = mNextCameraInfo.viewportHeight;
         mCamera.position.set(mNextCameraInfo.position, 0);

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -81,10 +81,9 @@ abstract class CameraUpdater {
         mCamera.viewportHeight = mNextCameraInfo.viewportHeight;
         mCamera.position.set(mNextCameraInfo.position, 0);
         mCamera.up.set(
-            (float) Math.cos(mNextCameraInfo.cameraUp), 
-            (float) Math.sin(mNextCameraInfo.cameraUp),
-            0
-        );
+                (float) Math.cos(mNextCameraInfo.cameraUp),
+                (float) Math.sin(mNextCameraInfo.cameraUp),
+                0);
         mCamera.update();
 
         // Swap instances

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -78,15 +78,13 @@ abstract class CameraUpdater {
 
     void applyChanges() {
         // Apply changes
-        switch (GamePlay.instance.cameraMode) {
-            case HeadingUpCamera:
-                mCamera.up.set(
-                        (float) Math.cos(mNextCameraInfo.cameraUp),
-                        (float) Math.sin(mNextCameraInfo.cameraUp),
-                        0);
-                break;
-            default:
-                mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
+        if (GamePlay.instance.headingUpCamera) {
+            mCamera.up.set(
+                    (float) Math.cos(mNextCameraInfo.cameraUp),
+                    (float) Math.sin(mNextCameraInfo.cameraUp),
+                    0);
+        } else {
+            mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
         }
         mCamera.viewportWidth = mNextCameraInfo.viewportWidth;
         mCamera.viewportHeight = mNextCameraInfo.viewportHeight;

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -18,6 +18,7 @@
  */
 package com.agateau.pixelwheels.racescreen;
 
+import com.agateau.pixelwheels.GamePlay;
 import com.agateau.pixelwheels.GameWorld;
 import com.agateau.pixelwheels.map.Track;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -77,13 +78,19 @@ abstract class CameraUpdater {
 
     void applyChanges() {
         // Apply changes
+        switch (GamePlay.instance.cameraMode) {
+            case HeadingUpCamera:
+                mCamera.up.set(
+                        (float) Math.cos(mNextCameraInfo.cameraUp),
+                        (float) Math.sin(mNextCameraInfo.cameraUp),
+                        0);
+                break;
+            default:
+                mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
+        }
         mCamera.viewportWidth = mNextCameraInfo.viewportWidth;
         mCamera.viewportHeight = mNextCameraInfo.viewportHeight;
         mCamera.position.set(mNextCameraInfo.position, 0);
-        mCamera.up.set(
-                (float) Math.cos(mNextCameraInfo.cameraUp),
-                (float) Math.sin(mNextCameraInfo.cameraUp),
-                0);
         mCamera.update();
 
         // Swap instances

--- a/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/CameraUpdater.java
@@ -38,6 +38,8 @@ abstract class CameraUpdater {
         float viewportWidth;
         float viewportHeight;
         Vector2 position = new Vector2();
+        float cameraUp = 0;
+        float cameraAhead = 0;
         float zoom = 1;
 
         void clampPositionToTrack(Track track) {
@@ -74,12 +76,15 @@ abstract class CameraUpdater {
     public abstract void update(float delta);
 
     void applyChanges() {
-        mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
-
         // Apply changes
         mCamera.viewportWidth = mNextCameraInfo.viewportWidth;
         mCamera.viewportHeight = mNextCameraInfo.viewportHeight;
         mCamera.position.set(mNextCameraInfo.position, 0);
+        mCamera.up.set(
+            (float) Math.cos(mNextCameraInfo.cameraUp), 
+            (float) Math.sin(mNextCameraInfo.cameraUp),
+            0
+        );
         mCamera.update();
 
         // Swap instances

--- a/core/src/com/agateau/pixelwheels/racescreen/FreeCameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/FreeCameraUpdater.java
@@ -73,6 +73,8 @@ class FreeCameraUpdater extends CameraUpdater {
         // Compute pos
         mNextCameraInfo.position.x = mCameraInfo.position.x + dx;
         mNextCameraInfo.position.y = mCameraInfo.position.y + dy;
+
+        mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
         applyChanges();
     }
 

--- a/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
@@ -80,14 +80,10 @@ public class GameRenderer {
         mCamera = new OrthographicCamera();
         if (GamePlay.instance.freeCamera) {
             mCameraUpdater = new FreeCameraUpdater(mWorld);
+        } else if (GamePlay.instance.headingUpCamera) {
+            mCameraUpdater = new HeadingUpCameraUpdater(mWorld, racer);
         } else {
-            switch (GamePlay.instance.cameraMode) {
-                case HeadingUpCamera:
-                    mCameraUpdater = new HeadingUpCameraUpdater(mWorld, racer);
-                    break;
-                default:
-                    mCameraUpdater = new RacerCameraUpdater(mWorld, racer);
-            }
+            mCameraUpdater = new RacerCameraUpdater(mWorld, racer);
         }
         mRenderer =
                 new OrthogonalTiledMapRenderer(mTrack.getMap(), Constants.UNIT_FOR_PIXEL, mBatch);

--- a/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
@@ -213,14 +213,7 @@ public class GameRenderer {
     }
 
     private void updateMapRendererCamera() {
-        float width = mCamera.viewportWidth * mCamera.zoom;
-        float height = mCamera.viewportHeight * mCamera.zoom;
-        mRenderer.setView(
-                mCamera.combined,
-                mCamera.position.x - width / 2,
-                mCamera.position.y - height / 2,
-                width,
-                height);
+        mRenderer.setView(mCamera);
     }
 
     private final Vector3 sTmp3 = new Vector3();

--- a/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
@@ -67,7 +67,12 @@ public class GameRenderer {
     private final PerformanceCounter mGameObjectPerformanceCounter;
     private final PerformanceCounter mSetupPerformanceCounter;
 
-    public GameRenderer(GameWorld world, Racer racer, Batch batch, PerformanceCounters counters) {
+    public GameRenderer(
+            GameWorld world,
+            Racer racer,
+            Batch batch,
+            boolean headingUp,
+            PerformanceCounters counters) {
         mDebugRenderer = new Box2DDebugRenderer();
         mWorld = world;
 
@@ -80,7 +85,7 @@ public class GameRenderer {
         mCamera = new OrthographicCamera();
         if (GamePlay.instance.freeCamera) {
             mCameraUpdater = new FreeCameraUpdater(mWorld);
-        } else if (GamePlay.instance.headingUpCamera) {
+        } else if (headingUp) {
             mCameraUpdater = new HeadingUpCameraUpdater(mWorld, racer);
         } else {
             mCameraUpdater = new RacerCameraUpdater(mWorld, racer);

--- a/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
@@ -81,7 +81,13 @@ public class GameRenderer {
         if (GamePlay.instance.freeCamera) {
             mCameraUpdater = new FreeCameraUpdater(mWorld);
         } else {
-            mCameraUpdater = new RacerCameraUpdater(mWorld, racer);
+            switch (GamePlay.instance.cameraMode) {
+                case HeadingUpCamera:
+                    mCameraUpdater = new HeadingUpCameraUpdater(mWorld, racer);
+                    break;
+                default:
+                    mCameraUpdater = new RacerCameraUpdater(mWorld, racer);
+            }
         }
         mRenderer =
                 new OrthogonalTiledMapRenderer(mTrack.getMap(), Constants.UNIT_FOR_PIXEL, mBatch);
@@ -213,7 +219,20 @@ public class GameRenderer {
     }
 
     private void updateMapRendererCamera() {
-        mRenderer.setView(mCamera);
+        switch (GamePlay.instance.cameraMode) {
+            case HeadingUpCamera:
+                mRenderer.setView(mCamera);
+                break;
+            default:
+                float width = mCamera.viewportWidth * mCamera.zoom;
+                float height = mCamera.viewportHeight * mCamera.zoom;
+                mRenderer.setView(
+                        mCamera.combined,
+                        mCamera.position.x - width / 2,
+                        mCamera.position.y - height / 2,
+                        width,
+                        height);
+        }
     }
 
     private final Vector3 sTmp3 = new Vector3();

--- a/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/GameRenderer.java
@@ -219,20 +219,7 @@ public class GameRenderer {
     }
 
     private void updateMapRendererCamera() {
-        switch (GamePlay.instance.cameraMode) {
-            case HeadingUpCamera:
-                mRenderer.setView(mCamera);
-                break;
-            default:
-                float width = mCamera.viewportWidth * mCamera.zoom;
-                float height = mCamera.viewportHeight * mCamera.zoom;
-                mRenderer.setView(
-                        mCamera.combined,
-                        mCamera.position.x - width / 2,
-                        mCamera.position.y - height / 2,
-                        width,
-                        height);
-        }
+        mRenderer.setView(mCamera);
     }
 
     private final Vector3 sTmp3 = new Vector3();

--- a/core/src/com/agateau/pixelwheels/racescreen/RaceScreen.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/RaceScreen.java
@@ -107,7 +107,12 @@ public class RaceScreen extends ScreenAdapter {
         createCountDownHudController();
         for (Racer racer : mGameWorld.getPlayerRacers()) {
             GameRenderer renderer =
-                    new GameRenderer(mGameWorld, racer, batch, mPerformanceCounters);
+                    new GameRenderer(
+                            mGameWorld,
+                            racer,
+                            batch,
+                            mGame.getConfig().headingUpCamera,
+                            mPerformanceCounters);
             mGameRenderers.add(renderer);
             mRacerHudControllers.add(createRacerHudController(mGameWorld.getTrack(), racer));
         }

--- a/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
@@ -24,7 +24,6 @@ import com.agateau.pixelwheels.GameWorld;
 import com.agateau.pixelwheels.racer.Racer;
 import com.agateau.pixelwheels.racer.Vehicle;
 import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.math.Vector2;
 
 /** A CameraUpdater tracking a racer */
 class RacerCameraUpdater extends CameraUpdater {
@@ -52,19 +51,21 @@ class RacerCameraUpdater extends CameraUpdater {
         mNextCameraInfo.viewportWidth = viewportWidth;
         mNextCameraInfo.viewportHeight = viewportHeight;
 
-        if(vehicle.isFlying() || vehicle.isFalling()) {
+        if (vehicle.isFlying() || vehicle.isFalling()) {
             // keep camera from rotating
             mNextCameraInfo.cameraUp = mCameraInfo.cameraUp;
         } else {
             // reflect how the vehicle is turning
             final float steerMag = vehicle.isDrifting() ? 0.65f : 0.32f;
             final float bodyAngle = vehicle.getBody().getAngle();
-            for(Vehicle.WheelInfo wi : vehicle.getWheelInfos()) {
+            for (Vehicle.WheelInfo wi : vehicle.getWheelInfos()) {
                 final float wheelAngle = wi.joint.getLowerLimit();
                 final float targetUp = bodyAngle - steerMag * wheelAngle;
-                mNextCameraInfo.cameraUp = mCameraInfo.cameraUp + 
-                    // smooth the camera turning
-                    0.12f * (targetUp - mCameraInfo.cameraUp);
+                mNextCameraInfo.cameraUp =
+                        mCameraInfo.cameraUp
+                                +
+                                // smooth the camera turning
+                                0.12f * (targetUp - mCameraInfo.cameraUp);
                 break; // use only the 1st wheel,
                 // assuming all wheels have the same angle
             }
@@ -72,13 +73,18 @@ class RacerCameraUpdater extends CameraUpdater {
 
         // Compute pos
         float advance = Math.min(viewportWidth, viewportHeight) * Constants.CAMERA_ADVANCE_PERCENT;
-        if(vehicle.isBraking()) {
+        if (vehicle.isBraking()) {
             advance *= 0.8; // make feel the breaking
         }
         // smooth the camera moving
-        mNextCameraInfo.cameraAhead = mCameraInfo.cameraAhead + 0.12f * (advance - mCameraInfo.cameraAhead);
+        mNextCameraInfo.cameraAhead =
+                mCameraInfo.cameraAhead + 0.12f * (advance - mCameraInfo.cameraAhead);
         // calculate & set next camera position
-        mNextCameraInfo.position.set(mNextCameraInfo.cameraAhead, 0).rotateRad(mNextCameraInfo.cameraUp).add(vehicle.getPosition());
+        mNextCameraInfo
+                .position
+                .set(mNextCameraInfo.cameraAhead, 0)
+                .rotateRad(mNextCameraInfo.cameraUp)
+                .add(vehicle.getPosition());
         limitZoomChange(delta);
         applyChanges();
     }

--- a/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
@@ -74,7 +74,10 @@ class RacerCameraUpdater extends CameraUpdater {
         // Compute pos
         float advance = Math.min(viewportWidth, viewportHeight) * Constants.CAMERA_ADVANCE_PERCENT;
         if (vehicle.isBraking()) {
-            advance *= 0.8; // make feel the breaking
+            advance *= 0.8; // make feel the braking
+            // TODO maybe more experiments about this
+            // * shorten the distance gives the feel the camera dragged the car
+            // * lengthen the distance gives the feel that the car dragged the camera
         }
         // smooth the camera moving
         mNextCameraInfo.cameraAhead =

--- a/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
@@ -65,6 +65,7 @@ class RacerCameraUpdater extends CameraUpdater {
             sDelta.limit(MAX_CAMERA_DELTA * delta);
         }
         limitZoomChange(delta);
+        mNextCameraInfo.clampPositionToTrack(mWorld.getTrack());
         applyChanges();
     }
 }

--- a/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/RacerCameraUpdater.java
@@ -32,7 +32,6 @@ class RacerCameraUpdater extends CameraUpdater {
     private static final float MIN_ZOOM = 0.6f;
     private static final float MAX_ZOOM = 2.1f;
 
-    private final Vector2 sDelta = new Vector2();
     private final Racer mRacer;
 
     RacerCameraUpdater(GameWorld world, Racer racer) {
@@ -42,7 +41,6 @@ class RacerCameraUpdater extends CameraUpdater {
 
     @Override
     public void update(float delta) {
-        boolean immediate = delta < 0;
         Vehicle vehicle = mRacer.getVehicle();
 
         // Compute viewport size
@@ -54,16 +52,33 @@ class RacerCameraUpdater extends CameraUpdater {
         mNextCameraInfo.viewportWidth = viewportWidth;
         mNextCameraInfo.viewportHeight = viewportHeight;
 
+        if(vehicle.isFlying() || vehicle.isFalling()) {
+            // keep camera from rotating
+            mNextCameraInfo.cameraUp = mCameraInfo.cameraUp;
+        } else {
+            // reflect how the vehicle is turning
+            final float steerMag = vehicle.isDrifting() ? 0.65f : 0.32f;
+            final float bodyAngle = vehicle.getBody().getAngle();
+            for(Vehicle.WheelInfo wi : vehicle.getWheelInfos()) {
+                final float wheelAngle = wi.joint.getLowerLimit();
+                final float targetUp = bodyAngle - steerMag * wheelAngle;
+                mNextCameraInfo.cameraUp = mCameraInfo.cameraUp + 
+                    // smooth the camera turning
+                    0.12f * (targetUp - mCameraInfo.cameraUp);
+                break; // use only the 1st wheel,
+                // assuming all wheels have the same angle
+            }
+        }
+
         // Compute pos
         float advance = Math.min(viewportWidth, viewportHeight) * Constants.CAMERA_ADVANCE_PERCENT;
-        sDelta.set(advance, 0)
-                .rotate(mRacer.getCameraAngle())
-                .add(vehicle.getPosition())
-                .sub(mCameraInfo.position);
-        mNextCameraInfo.position.set(mCameraInfo.position).add(sDelta);
-        if (!immediate) {
-            sDelta.limit(MAX_CAMERA_DELTA * delta);
+        if(vehicle.isBraking()) {
+            advance *= 0.8; // make feel the breaking
         }
+        // smooth the camera moving
+        mNextCameraInfo.cameraAhead = mCameraInfo.cameraAhead + 0.12f * (advance - mCameraInfo.cameraAhead);
+        // calculate & set next camera position
+        mNextCameraInfo.position.set(mNextCameraInfo.cameraAhead, 0).rotateRad(mNextCameraInfo.cameraUp).add(vehicle.getPosition());
         limitZoomChange(delta);
         applyChanges();
     }

--- a/core/src/com/agateau/pixelwheels/screens/ConfigScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/ConfigScreen.java
@@ -269,8 +269,8 @@ public class ConfigScreen extends PwStageScreen {
                         });
         group.addItemWithLabel(tr("Music:"), musicSwitch);
 
+        group.addTitleLabel(tr("Video"));
         if (PlatformUtils.isDesktop()) {
-            group.addTitleLabel(tr("Video"));
             final SwitchMenuItem fullscreenSwitch = new SwitchMenuItem(mMenu);
             fullscreenSwitch.setChecked(gameConfig.fullscreen);
             fullscreenSwitch
@@ -286,6 +286,20 @@ public class ConfigScreen extends PwStageScreen {
                             });
             group.addItemWithLabel(tr("Fullscreen:"), fullscreenSwitch);
         }
+
+        final SwitchMenuItem headingUpCameraSwitch = new SwitchMenuItem(mMenu);
+        headingUpCameraSwitch.setChecked(gameConfig.headingUpCamera);
+        headingUpCameraSwitch
+                .getActor()
+                .addListener(
+                        new ChangeListener() {
+                            @Override
+                            public void changed(ChangeEvent event, Actor actor) {
+                                gameConfig.headingUpCamera = headingUpCameraSwitch.isChecked();
+                                gameConfig.flush();
+                            }
+                        });
+        group.addItemWithLabel(tr("Rotate camera\n(experimental):"), headingUpCameraSwitch);
     }
 
     private String getLanguageText() {

--- a/tools/apply-codingstyle
+++ b/tools/apply-codingstyle
@@ -31,12 +31,14 @@ Apply coding style.
 Options:
   -h, --help          display this usage message and exit
   -c, --check         check if coding style is OK, do not apply it
+  -d, --download-only download the formatter and stop
 EOF
 
     exit 1
 }
 
 check=0
+download_only=0
 files=""
 while [ $# -gt 0 ] ; do
     case "$1" in
@@ -45,6 +47,9 @@ while [ $# -gt 0 ] ; do
         ;;
     -c|--check)
         check=1
+        ;;
+    -d|--download-only)
+        download_only=1
         ;;
     -*)
         usage "Unknown option '$1'"
@@ -57,6 +62,10 @@ while [ $# -gt 0 ] ; do
 done
 
 download_formatter
+
+if [ $download_only -eq 1 ] ; then
+    exit 0
+fi
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
I'm not a game dev myself, just came to this game by accident and enjoyed it.

But currently as "retro" as it is, the driving experience feels more like controlling a RC car model. I think I would enjoy more in more realistic feeling of heading up mode, then tinkered with the code base, and come with a basic hack of the desired feel.

Current changes are way very basic and lack a lot of adjustments to get it all right, yet it's only 3 lines changed atm.

I'd like to know what you think about this mode before any proceeding, and definitely need your help and efforts to get it all done.

A few of my thoughts what can/shall be done:

1. make it an option to race in this mode, maybe better along with portrait display mode of the phone
2. proper camera handling when the car is moving back
3. fix clipping for the camera
4. further tune the physics for driving experience

WRT 4, I'd suggest that the acceleration should be greatly slowed down (I drive comfortably only with force 30 instead of the default 50), maybe add shifting of a real car and physics / sounds for the engine to work at respective RPMs. Also physics to slow down the turning to make the feel more apparent, i.e. the camera heads up the car's real moving direction, when the car turns, the gamer should see the car body tilts for a moment before the drifting force pushed the car's velocity to the desired direction, drifting or not should have different physical models.

Hope you find this idea approachable & worth trying.
