### PR TITLE
additional catchup mechanic by lowering maxspeed

### DIFF
--- a/core/src/com/agateau/pixelwheels/GamePlay.java
+++ b/core/src/com/agateau/pixelwheels/GamePlay.java
@@ -45,12 +45,14 @@ public class GamePlay {
 
     public int viewportWidth = 60;
 
-    public int turboStrength = 200;
+    public int turboStrength = 70;
     public float turboDuration = 0.5f;
 
     // When an AI is better ranked than a player, set its max speed to this percent of the best max
     // speed
     public float aiSpeedLimiter = 0.8f;
+
+    public float catchupFactor = 20;
 
     public boolean oneLapOnly = false;
     public boolean freeCamera = false;

--- a/core/src/com/agateau/pixelwheels/racer/Vehicle.java
+++ b/core/src/com/agateau/pixelwheels/racer/Vehicle.java
@@ -79,6 +79,7 @@ public class Vehicle implements Racer.Component, Disposable {
     private boolean mStopped = false;
     private Material mMaterial = Material.ROAD;
     private float mSpeedLimiter = 1f;
+    private float mMaxSpeed = GamePlay.instance.maxSpeed;
     private boolean mFlying = false;
 
     private Probe mProbe = null;
@@ -255,6 +256,14 @@ public class Vehicle implements Racer.Component, Disposable {
         mSpeedLimiter = speedLimiter;
     }
 
+    public float getMaxSpeed() {
+        return mMaxSpeed;
+    }
+
+    public void setMaxSpeed(float maxSpeed) {
+        mMaxSpeed = maxSpeed;
+    }
+
     /** Returns the angle the car is facing */
     public float getAngle() {
         return AgcMathUtils.normalizeAngle(mBody.getAngle() * MathUtils.radiansToDegrees);
@@ -381,7 +390,7 @@ public class Vehicle implements Racer.Component, Disposable {
         float steerAngle = computeSteerAngle() * MathUtils.degRad;
         for (WheelInfo info : mWheels) {
             float angle = info.steeringFactor * steerAngle;
-            info.wheel.adjustSpeed(speedDelta);
+            info.wheel.adjustSpeed(speedDelta, mMaxSpeed);
             info.joint.setLimits(angle, angle);
         }
     }

--- a/core/src/com/agateau/pixelwheels/racer/Wheel.java
+++ b/core/src/com/agateau/pixelwheels/racer/Wheel.java
@@ -183,14 +183,13 @@ public class Wheel implements Disposable {
         return mMaterial.getSpeed();
     }
 
-    public void adjustSpeed(float amount) {
+    public void adjustSpeed(float amount, float maxSpeed) {
         if (amount == 0) {
             return;
         }
         final float currentSpeed = mBody.getLinearVelocity().len() * Box2DUtils.MS_TO_KMH;
 
-        final float limit =
-                1 - 0.2f * Interpolation.sineOut.apply(currentSpeed / GamePlay.instance.maxSpeed);
+        final float limit = 1 - 0.2f * Interpolation.sineOut.apply(currentSpeed / maxSpeed);
         amount *= limit;
 
         float force = mMaxDrivingForce * amount;


### PR DESCRIPTION
the catchup mechanic in master branch has a disadvantage that it only leans toward player against AI. actually, when the player leads a lot in the race, he/she may possibly want the AIs to catchup too, so as to fight more with them for more fun.

this PR experiments with the idea to lower the maxSpeed limit of a car one before another in order.

added GP param `catchupFactor = 20`, which would effectively grant the behinder 1x advantage wrt maxSpeed, for every 1/20 distance of a single lap, that between the 2 cars.

`turboStrength = 200` is found so large that it'll overwhelm the catchup effect added, so lowered to `70` initially for experimenting purpose.

please try & see how you feel about the effects so far?
