### PR TITLE
bugfix: helicopter sound stays forever if was playing when back from finish screen

### DIFF
--- a/.changes/unreleased/Fixed-20240512-164437.yaml
+++ b/.changes/unreleased/Fixed-20240512-164437.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: helicopter sound stay forever
+time: 2024-05-12T16:44:37.16463314+08:00

--- a/core/src/com/agateau/pixelwheels/racescreen/Helicopter.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/Helicopter.java
@@ -180,6 +180,9 @@ public class Helicopter extends GameObjectAdapter implements Pool.Poolable, Disp
     @Override
     public void dispose() {
         sPool.free(this);
+        if (mSoundPlayer != null) {
+            mSoundPlayer.stop();
+        }
     }
 
     public void setDestination(OrientedPoint point) {

--- a/core/src/com/agateau/pixelwheels/racescreen/Helicopter.java
+++ b/core/src/com/agateau/pixelwheels/racescreen/Helicopter.java
@@ -179,10 +179,10 @@ public class Helicopter extends GameObjectAdapter implements Pool.Poolable, Disp
 
     @Override
     public void dispose() {
-        sPool.free(this);
         if (mSoundPlayer != null) {
             mSoundPlayer.stop();
         }
+        sPool.free(this);
     }
 
     public void setDestination(OrientedPoint point) {


### PR DESCRIPTION
bugfix: helicopter sound stays forever if was playing when back from finish screen.