### PR TITLE
fix select track nav

### DIFF
--- a/android/assets/screens/selecttrack.gdxui
+++ b/android/assets/screens/selecttrack.gdxui
@@ -3,15 +3,18 @@
     <AnchorGroup id="root" gridSize="20">
         <Label id="titleLabel" style="title" topCenter="root.topCenter 0 -1g">Select Track</Label>
 
-        <Menu id="menu" topCenter="titleLabel.bottomCenter 0 0" width="700" height="400"/>
+        <Image tiled="true" atlas="ui" name="garage-ground" topCenter="titleLabel.bottomCenter 0 -0.2"
+            width="960px" height="178px"/>
+
+        <Menu id="menu" topCenter="titleLabel.bottomCenter 0 -0.5" width="700" height="400"/>
 
         <Label id="trackNameLabel" topCenter="menu.bottomCenter 0 0" align="center"/>
         <Label id="unlockHintLabel" topCenter="$prev.bottomCenter 0 -1" align="center" style="small"/>
 
-        <Label id="lapRecordsLabel" bottomRight="root.bottomCenter -1.5g 4.5g" width="300" align="topCenter" style="small">Best Lap</Label>
+        <Label id="lapRecordsLabel" bottomRight="root.bottomCenter -1.5g 3.9g" width="300" align="topCenter" style="small">Best Lap</Label>
         <Table id="lapRecordsTable" topLeft="$prev.bottomLeft 0 0" width="300"/>
 
-        <Label id="totalRecordsLabel" bottomLeft="root.bottomCenter 1.5g 4.5g" width="300" align="topCenter" style="small">Best Total</Label>
+        <Label id="totalRecordsLabel" bottomLeft="root.bottomCenter 1.5g 3.9g" width="300" align="topCenter" style="small">Best Total</Label>
         <Table id="totalRecordsTable" topLeft="$prev.bottomLeft 0 0" width="300"/>
     </AnchorGroup>
 </gdxui>

--- a/android/assets/ui/uiskin.gdxjson
+++ b/android/assets/ui/uiskin.gdxjson
@@ -36,7 +36,6 @@
             up: rectbutton,
             down: rectbutton-down,
             disabled: rectbutton-disabled,
-            unpressedOffsetY: 2,
             pressedOffsetY: -2
         }
     },

--- a/core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java
+++ b/core/src/com/agateau/pixelwheels/screens/SelectTrackScreen.java
@@ -36,6 +36,7 @@ import com.agateau.ui.anchor.AnchorGroup;
 import com.agateau.ui.menu.CornerMenuButton;
 import com.agateau.ui.menu.GridMenuItem;
 import com.agateau.ui.menu.Menu;
+import com.agateau.ui.menu.MenuItemListener;
 import com.agateau.ui.uibuilder.UiBuilder;
 import com.agateau.utils.FileUtils;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -192,11 +193,33 @@ public class SelectTrackScreen extends PwStageScreen {
         mChampionshipSelector.setSelectionListener(
                 new GridMenuItem.SelectionListener<Championship>() {
                     @Override
-                    public void currentChanged(Championship item, int index) {}
+                    public void currentChanged(Championship item, int index) {
+                        mChampionshipSelector.setSelected(item);
+                        mTrackSelector.setCurrentChampionship(item);
+
+                        // Unselect the current track, forcing GridMenuItem to set the first item as
+                        // the current one.
+                        mTrackSelector.setSelected(null);
+
+                        // Force update of track: because if mTrackSelector current index has not
+                        // changed then currentChanged() has not been called
+                        updateTrackDetails(mTrackSelector.getCurrent());
+
+                        updateNextButton();
+                    }
 
                     @Override
-                    public void selectionConfirmed() {
-                        mTrackSelector.setCurrentChampionship(mChampionshipSelector.getSelected());
+                    public void selectionConfirmed() {}
+                });
+
+        // Move the focus to the track selector when championship selector is triggered. Do not do
+        // this with SelectionListener.selectionConfirmed() because the championship selector
+        // selects its current item every time the current changes, so it would move the focus when
+        // changing the current championship with the keyboard.
+        mChampionshipSelector.setListener(
+                new MenuItemListener() {
+                    @Override
+                    public void triggered() {
                         menu.setCurrentItem(mTrackSelector);
                     }
                 });
@@ -211,7 +234,6 @@ public class SelectTrackScreen extends PwStageScreen {
         mTrackSelector.init(assets, mGame.getRewardManager(), currentTrack.getChampionship());
         mTrackSelector.setCurrent(currentTrack);
         menu.addItem(mTrackSelector);
-        menu.setCurrentItem(mTrackSelector);
 
         mTrackSelector.setSelectionListener(
                 new GridMenuItem.SelectionListener<Track>() {

--- a/core/src/com/agateau/ui/anchor/PositionRule.java
+++ b/core/src/com/agateau/ui/anchor/PositionRule.java
@@ -38,13 +38,14 @@ public class PositionRule implements AnchorRule {
 
     @Override
     public void apply() {
-        // Compute reference position
-        Vector2 referencePos =
+        // Compute reference position.
+        // referenceOffset is the offset relative to the bottom-left corner of reference.
+        Vector2 referenceOffset =
                 new Vector2(
                         reference.getWidth() * referenceAnchor.hPercent,
                         reference.getHeight() * referenceAnchor.vPercent);
 
-        Vector2 stagePos = reference.localToStageCoordinates(referencePos);
+        Vector2 stagePos = reference.localToStageCoordinates(referenceOffset);
 
         // Apply space
         stagePos.add(hSpace, vSpace);

--- a/core/src/com/agateau/ui/menu/FocusIndicator.java
+++ b/core/src/com/agateau/ui/menu/FocusIndicator.java
@@ -76,6 +76,15 @@ class FocusIndicator {
 
         float alpha = mAlpha * (1 - BLINK_DEPTH / 2 + BLINK_DEPTH / 2 * k);
 
+        drawIndicator(batch, x, y, width, height, alpha);
+    }
+
+    /**
+     * Helper method to draw the indicator independently of the current value of mAlpha Used by
+     * other UI components
+     */
+    public void drawIndicator(
+            Batch batch, float x, float y, float width, float height, float alpha) {
         mOldBatchColor.set(batch.getColor());
         batch.setColor(alpha, alpha, alpha, alpha);
 

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -337,7 +337,7 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         Cursor cursor = mCursors.get(cursorIdx);
         if (item == null) {
             cursor.setCurrentIndex(0);
-            if (PlatformUtils.isTouchUi() || select) {
+            if (select) {
                 cursor.setSelectedIndex(INVALID_INDEX);
             }
             return;
@@ -348,7 +348,7 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
             return;
         }
         cursor.setCurrentIndex(index);
-        if (PlatformUtils.isTouchUi() || select) {
+        if (select) {
             cursor.setSelectedIndex(index);
         }
     }

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -330,7 +330,7 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         mCursors.get(idx).mSelectionListener = selectionListener;
     }
 
-    public void setCurrentAndSelect(int cursorIdx, T item, boolean select) {
+    private void setCurrentAndSelect(int cursorIdx, T item, boolean select) {
         Cursor cursor = mCursors.get(cursorIdx);
         if (item == null) {
             cursor.setCurrentIndex(0);

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -337,6 +337,9 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         Cursor cursor = mCursors.get(cursorIdx);
         if (item == null) {
             cursor.setCurrentIndex(0);
+            if (PlatformUtils.isTouchUi() || select) {
+                cursor.setSelectedIndex(INVALID_INDEX);
+            }
             return;
         }
         int index = mItems.indexOf(item, true);

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -185,6 +185,9 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         }
 
         public void setCurrentIndex(int currentIndex) {
+            if (mCurrentIndex == currentIndex) {
+                return;
+            }
             if (mCurrentIndex != INVALID_INDEX) {
                 mFocusIndicators.get(mCurrentIndex).setFocused(false);
             }

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -297,6 +297,10 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
         mCursors.add(new Cursor(mCursors.size));
     }
 
+    public void setListener(MenuItemListener listener) {
+        setListener(0, listener);
+    }
+
     public void setListener(int idx, MenuItemListener listener) {
         mCursors.get(idx).mMenuItemListener = listener;
     }

--- a/core/src/com/agateau/ui/menu/GridMenuItem.java
+++ b/core/src/com/agateau/ui/menu/GridMenuItem.java
@@ -36,6 +36,7 @@ import com.badlogic.gdx.utils.Array;
 /** A MenuItem to display a grid of custom elements */
 public class GridMenuItem<T> extends Widget implements MenuItem {
     public static final int INVALID_INDEX = -1;
+    private static final float UNFOCUSED_CURRENT_INDICATOR_ALPHA = 0.7f;
     private final Menu mMenu;
     private Array<T> mItems;
     private ItemRenderer<T> mRenderer;
@@ -484,6 +485,15 @@ public class GridMenuItem<T> extends Widget implements MenuItem {
                             getY() + y + rect.y,
                             rect.width,
                             rect.height);
+                } else if (idx == cursor.mCurrentIndex) {
+                    FocusIndicator focusIndicator = cursor.mFocusIndicators.get(idx);
+                    focusIndicator.drawIndicator(
+                            batch,
+                            getX() + x + rect.x,
+                            getY() + y + rect.y,
+                            rect.width,
+                            rect.height,
+                            UNFOCUSED_CURRENT_INDICATOR_ALPHA);
                 }
 
                 if (idx == cursor.mSelectedIndex) {


### PR DESCRIPTION
- **PositionRule: Improve documentation**
- **SelectTrack: set a different background for the championship selector**
- **GridMenuItem: highlight the current item when unfocused**
- **GridMenuItem: make internal method private**
- **GridMenuItem: avoid infinite loop when calling setCurrentIndex()**
- **GridMenuItem: clear selected index when current**
- **GridMenuItem: remove touch-specific behavior in setCurrentAndSelect**
- **SelectTrack: fix track list not changing immediately when championship is clicked in touch mode**
- **ImageButton: fix image being too high in the button frame**
