### PR TITLE
Complement com.agateau.PixelWheels.metainfo.xml

### DIFF
--- a/tools/packaging/linux/share/metainfo/com.agateau.PixelWheels.metainfo.xml
+++ b/tools/packaging/linux/share/metainfo/com.agateau.PixelWheels.metainfo.xml
@@ -35,6 +35,7 @@
   <url type="homepage">https://agateau.com/projects/pixelwheels</url>
   <url type="bugtracker">https://github.com/agateau/pixelwheels/issues</url>
   <url type="donation">https://agateau.com/support</url>
+  <url type="vcs-browser">https://github.com/agateau/pixelwheels</url>
 
   <launchable type="desktop-id">com.agateau.PixelWheels.desktop</launchable>
 


### PR DESCRIPTION
Based on what is already available in the [LinuxPhoneApps listing](https://linuxphoneapps.org/games/com.agateau.pixelwheels) I added some missing metainfo:
- Adds vcs-browser url