### PR TITLE
Use best lap time as tiebreaker for same-time finishes

### DIFF
--- a/core/src/com/agateau/pixelwheels/racer/Racer.java
+++ b/core/src/com/agateau/pixelwheels/racer/Racer.java
@@ -396,7 +396,12 @@ public class Racer extends GameObjectAdapter
         if (c1.hasFinishedRace() && c2.hasFinishedRace()) {
             // If both racers have finished, consider the racer with the shortest total time to be
             // in front of the other
-            return Float.compare(c2.getTotalTime(), c1.getTotalTime());
+            int cmp = Float.compare(c2.getTotalTime(), c1.getTotalTime());
+            if (cmp != 0) {
+                return cmp;
+            }
+            // Tiebreaker: racer with the faster best lap wins
+            return Float.compare(c2.getBestLapTime(), c1.getBestLapTime());
         }
         if (!c1.hasFinishedRace() && c2.hasFinishedRace()) {
             return -1;


### PR DESCRIPTION
Fixes #468

When two racers finish with the exact same total time, `compareRaceDistances()` returns 0 (equal). This causes inconsistent ranking between the HUD (which counts racers ahead via iteration) and the results screen (which sorts racers, reordering ties unpredictably).

Added a best-lap-time tiebreaker: when total times are equal, the racer with the faster best lap is ranked higher. This gives a deterministic result regardless of sort stability or array order.