### PR TITLE
fix: replace bitwise OR with logical OR in gamepad connection check

### DIFF
--- a/core/src/com/agateau/pixelwheels/gameinput/EnoughInputsChecker.java
+++ b/core/src/com/agateau/pixelwheels/gameinput/EnoughInputsChecker.java
@@ -95,7 +95,7 @@ public class EnoughInputsChecker {
     }
 
     private void onGamepadConnected() {
-        if (mInputCount == 0 | hasEnoughInputs()) {
+        if (mInputCount == 0 || hasEnoughInputs()) {
             return;
         }
         update();


### PR DESCRIPTION
In `onGamepadConnected()`, the condition used a bitwise OR (`|`) instead of a logical OR (`||`). This forces the evaluation of `hasEnoughInputs()` even when `mInputCount == 0` is already true.

Switching to a logical OR enables short-circuit evaluation, preventing unnecessary method execution and potential side effects. Found via SonarQube analysis.